### PR TITLE
fix(db): use plugin's own migrations instead of core

### DIFF
--- a/dashboard.go
+++ b/dashboard.go
@@ -8,11 +8,11 @@ import (
 	"go.lumeweb.com/portal-plugin-dashboard/internal"
 	"go.lumeweb.com/portal-plugin-dashboard/internal/api"
 	pluginConfig "go.lumeweb.com/portal-plugin-dashboard/internal/config"
+	"go.lumeweb.com/portal-plugin-dashboard/internal/db/migrations"
 	"go.lumeweb.com/portal-plugin-dashboard/internal/db/models"
 	"go.lumeweb.com/portal-plugin-dashboard/internal/provider"
 	pluginService "go.lumeweb.com/portal-plugin-dashboard/internal/service"
 	"go.lumeweb.com/portal/core"
-	"go.lumeweb.com/portal/db/migrations"
 	"go.lumeweb.com/portal/service"
 )
 

--- a/go.sum
+++ b/go.sum
@@ -693,8 +693,6 @@ go.lumeweb.com/portal-middleware v0.2.7 h1:2dImx++MVQaFzIEPEu9cPD1+HOgO9vvBiZGzg
 go.lumeweb.com/portal-middleware v0.2.7/go.mod h1:ASD8khWO5m6oDP4oBU9pieXIs87VtK/vYYaxF8XRCVc=
 go.lumeweb.com/portal-router v0.5.0 h1:BbmXRyFiz6NVKT6mCN6fnsb5zHveO2OOlQVieeuRUdk=
 go.lumeweb.com/portal-router v0.5.0/go.mod h1:DUbMdKbsDSh/iKI9/XVWSJKwOLMNDdQtlxCnHSOpqsQ=
-go.lumeweb.com/queryutil v0.3.4 h1:qhArbX9f+uevUV2+4UD1FMAmwkx1pWzrudjMymPCMQE=
-go.lumeweb.com/queryutil v0.3.4/go.mod h1:tcD4meQIXQYNjJ8i0dahCa8kpzQyks+d7PiC+qCXdNg=
 go.lumeweb.com/queryutil v0.3.5 h1:3S0MdR/zMognM4gb9sRMR8cjfXOXALaLVGz7WsGGotQ=
 go.lumeweb.com/queryutil v0.3.5/go.mod h1:tcD4meQIXQYNjJ8i0dahCa8kpzQyks+d7PiC+qCXdNg=
 go.lumeweb.com/web/go/portal-dashboard v0.0.0-20250531060339-104c4db9a6e6 h1:dDvOTon+D09aRt8LofqxVeh6q+3tY7Dp+Qieyl8i1lQ=

--- a/internal/db/migrations/migrations.go
+++ b/internal/db/migrations/migrations.go
@@ -1,0 +1,29 @@
+package migrations
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed mysql/*.sql
+var mysql embed.FS
+
+//go:embed sqlite/*.sql
+var sqlite embed.FS
+
+func GetMySQL() fs.FS {
+	sub, err := fs.Sub(mysql, "mysql")
+	if err != nil {
+		panic(err)
+	}
+
+	return sub
+}
+
+func GetSQLite() fs.FS {
+	sub, err := fs.Sub(sqlite, "sqlite")
+	if err != nil {
+		panic(err)
+	}
+	return sub
+}


### PR DESCRIPTION
- Removed dependency on portal core migrations package
- Added proper internal migrations package with embedded SQL files
- Updated dashboard.go imports to use internal/db/migrations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of database migrations for MySQL and SQLite, ensuring smoother updates and reliability.
- **Chores**
	- Updated internal management of migration files for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->