### PR TITLE
fix: update API key response type in swagger schema

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1146,7 +1146,7 @@ func (a *API) Configure(gRouter router.Router, accessSvc core.AccessService) err
 				router.WithPaginationParams(),
 				router.WithResponseHeaders(http.StatusOK, "List of API Keys", map[string]swagger.Schema{
 					"application/json": {
-						Value: queryutil.Response[*pluginDb.APIKey]{},
+						Value: queryutil.Response[*dto.APIKeyResponse]{},
 					},
 				}, nil),
 			),


### PR DESCRIPTION
Changed the response type in the swagger schema from pluginDb.APIKey to dto.APIKeyResponse for the API keys endpoint to ensure consistent response formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the API documentation for the "List API Keys" endpoint to reflect a more user-friendly response format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->