### PR TITLE
fix(api): ensure subdomain event fires after boot complete

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -8,9 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"image"
-	_ "image/jpeg"
-	_ "image/png" 
 	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
 	"io"
 	"net/http"
 	"net/url"
@@ -128,10 +128,10 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 			return nil
 		}),
 		core.ContextWithStartupFunc(func(ctx core.Context) error {
-			err := core.Fire(ctx, event.EVENT_USER_SERVICE_SUBDOMAIN_SET, event.NewUserServiceSubdomainSetEvent(api.Subdomain()))
-			if err != nil {
-				return err
-			}
+			core.Listen(ctx, event.EVENT_BOOT_COMPLETE, func(e *core.CoreEvent[event.BootCompleteEvent]) error {
+				return core.Fire(ctx, event.EVENT_USER_SERVICE_SUBDOMAIN_SET, event.NewUserServiceSubdomainSetEvent(api.Subdomain()))
+			})
+
 			return nil
 		}),
 


### PR DESCRIPTION
- Move subdomain event trigger to BOOT_COMPLETE listener
- Prevents race condition during startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by completing user service subdomain setup only after the app fully boots. Prevents missed initialization, reduces intermittent first-run failures, improves consistency across environments, and leads to more predictable sign-in and service availability at launch.

* **Style**
  * Standardized import ordering for consistency; no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->