### PR TITLE
refactor(api): change delete account endpoint to /api/account

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1230,7 +1230,7 @@ func (a *API) Configure(gRouter router.Router, accessSvc core.AccessService) err
 			),
 			router.WithAccess(""),
 		),
-		router.NewRoute(http.MethodDelete, "/api/account/delete", a.deleteAccount,
+		router.NewRoute(http.MethodDelete, "/api/account", a.deleteAccount,
 			router.WithSwaggerOptions(
 				router.WithSummary("Request account deletion"),
 				router.WithDescription("Initiates the process to delete the authenticated user's account."),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated the DELETE account API endpoint from /api/account/delete to /api/account.
  - HTTP method, handler behavior, authentication, middleware, and response format remain unchanged.
  - OpenAPI/Swagger documentation now reflects the new path.
  - No other endpoints are affected.
  - Action required: update any clients, scripts, or integrations that call the old path to use /api/account for account deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->