### PR TITLE
fix(api): handle existing account errors in email verification

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -268,6 +268,13 @@ func (a *API) verifyEmail(c echo.Context) error {
 
 	err := a.user.VerifyEmail(requestDto.Email, requestDto.Token)
 	if err != nil {
+		if core.IsAccountError(err) {
+			acctErr := core.AsAccountError(err)
+			if acctErr.IsErrorType(core.ErrKeyAccountAlreadyVerified) {
+				return c.NoContent(http.StatusOK) // idempotent success
+			}
+			return ctx.Error(acctErr, acctErr.HttpStatus())
+		}
 		acctErr := core.NewAccountError(core.ErrKeyDatabaseOperationFailed, err)
 		return ctx.Error(acctErr, acctErr.HttpStatus())
 	}


### PR DESCRIPTION
- Modified verifyEmail handler to properly propagate existing account errors
- Only wraps non-account errors in new AccountError

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Email verification now surfaces account-specific errors rather than always returning a generic database failure.
  - Already-verified accounts return 200 OK (idempotent success) instead of an error.
  - Successful verifications continue to return a 200 No Content response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->