### PR TITLE
refactor(api): return an error when email is already verified

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -282,7 +282,8 @@ func (a *API) verifyEmail(c echo.Context) error {
 		return ctx.Error(acctErr, acctErr.HttpStatus())
 	}
 	if verified {
-		return c.NoContent(http.StatusOK) // idempotent success
+		acctErr := core.NewAccountError(core.ErrKeyAccountAlreadyVerified, nil)
+		return ctx.Error(acctErr, acctErr.HttpStatus())
 	}
 
 	// Only attempt verification if not already verified


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email verification now reports when an address is already verified instead of indicating success. Clients will receive an appropriate response status and can show a clear message to users so they understand the account is already verified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->