### PR TITLE
refactor(api): change avatar_url to avatar

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1313,7 +1313,7 @@ func (a *API) setAvatarURL(ctx httputil.RequestContext, userID uint, responseDto
 	}
 	if exists {
 		host := a.http.APISubdomain(a.Name(), true)
-		responseDto.AvatarURL = fmt.Sprintf(AvatarURLFormat, host)
+		responseDto.Avatar = fmt.Sprintf(AvatarURLFormat, host)
 	}
 	return nil
 }

--- a/internal/api/dto/response.go
+++ b/internal/api/dto/response.go
@@ -72,7 +72,7 @@ type AccountInfoResponse struct {
 	Verified  bool      `json:"verified"`
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	OTP       bool      `json:"otp"`
-	AvatarURL string    `json:"avatar_url,omitempty"`
+	Avatar    string    `json:"avatar,omitempty"`
 }
 
 func (r *AccountInfoResponse) FromModel(user *models.User) error {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized avatar field naming in account info responses: avatar replaces avatar_url.
  - Existing avatar generation and formatting remain unchanged; image URLs and availability are unaffected.
  - No other response fields changed.
  - Client applications relying on avatar_url should update to use avatar to ensure avatar data continues to display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->