### PR TITLE
refactor(api): pass echo context to buildAuthCompleteURL and use request scheme

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -240,7 +240,7 @@ func (a *API) login(c echo.Context) error {
 		return httputil.EncodeResponse(ctx, responseModel, &responseDto)
 	}
 
-	redirectURL := a.buildAuthCompleteURL(_jwt, "")
+	redirectURL := a.buildAuthCompleteURL(c, _jwt, "")
 
 	// For non-OTP login, ensure remember cookie is properly set/cleared
 	a.storeRememberFlagInCookie(c, requestDto.Remember)
@@ -488,7 +488,7 @@ func (a *API) otpValidate(c echo.Context) error {
 		return ctx.Error(acctErr, acctErr.HttpStatus())
 	}
 
-	redirectURL := a.buildAuthCompleteURL(_jwt, "")
+	redirectURL := a.buildAuthCompleteURL(c, _jwt, "")
 
 	// Set the authentication cookie with the remember flag
 	if err := a.setAuthCookieWithRemember(c, _jwt, remember); err != nil {
@@ -1037,7 +1037,7 @@ func (a *API) setupOrLoginSocialUser(guser *goth.User, ctx httputil.RequestConte
 		return
 	}
 
-	redirectURL := a.buildAuthCompleteURL(_jwt, returnUrl)
+	redirectURL := a.buildAuthCompleteURL(c, _jwt, returnUrl)
 
 	http.Redirect(ctx.Response(), ctx.Request(), redirectURL, http.StatusFound)
 }
@@ -1845,7 +1845,7 @@ func processAvatar(imgData []byte) ([]byte, string, error) {
 	return buf.Bytes(), "image/webp", nil
 }
 
-func (a *API) buildAuthCompleteURL(token string, returnURL string) string {
+func (a *API) buildAuthCompleteURL(c echo.Context, token string, returnURL string) string {
 	cfg := a.ctx.Config().Config().Core
 	
 	// Determine effective port (prefer externalPort if set)
@@ -1860,10 +1860,10 @@ func (a *API) buildAuthCompleteURL(token string, returnURL string) string {
 		host = fmt.Sprintf("%s:%d", host, port)
 	}
 
-	// Use configured scheme (default to https)
-	scheme := "https"
-	if cfg.Scheme != "" {
-		scheme = cfg.Scheme
+	// Use scheme from request
+	scheme := "http"
+	if c.Request().URL != nil && c.Request().URL.Scheme == "https" {
+		scheme = "https"
 	}
 
 	// Validate and sanitize returnURL if provided


### PR DESCRIPTION
- Updated buildAuthCompleteURL to accept echo.Context parameter
- Changed scheme determination to use request URL scheme instead of config
- Updated all calls to buildAuthCompleteURL to pass the context