### PR TITLE
fix(api): disable filter parameters from operation schema due to panic issue

### DIFF
--- a/internal/api/api_operation.go
+++ b/internal/api/api_operation.go
@@ -104,7 +104,8 @@ func (a *API) buildOperationRoutes(authMw echo.MiddlewareFunc, accessMw echo.Mid
 				router.WithQueryParam("search", "Search term for filename or other relevant operation data", ""),
 				router.WithPaginationParams(),
 				router.WithSortParams(operationSchema.SortableFields()),
-				router.WithFilterParamsFromSchema(operationSchema),
+				//  TODO: Fix panic on processing schemas with pointers?
+				//	router.WithFilterParamsFromSchema(operationSchema),
 				router.WithSuccessResponse(http.StatusOK, "A list of operations",
 					router.WithJSONContent(queryutil.Response[*dto.OperationListItem]{}),
 					router.WithTotalCountHeader(),


### PR DESCRIPTION
- Temporarily commented out `router.WithFilterParamsFromSchema` for operation routes
- Added TODO comment to investigate and fix panic when processing schemas with pointers