### PR TITLE
refactor(api): replace request service with workflow service for operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.lumeweb.com/gswagger v0.20.10
 	go.lumeweb.com/httputil v0.5.3
-	go.lumeweb.com/portal v0.4.2-0.20250926222741-4b692c1ae488
+	go.lumeweb.com/portal v0.4.2-0.20250927013046-41c69f1889b1
 	go.lumeweb.com/portal-middleware v0.3.1
 	go.lumeweb.com/portal-router v0.6.7
 	go.lumeweb.com/queryutil v0.3.14

--- a/go.sum
+++ b/go.sum
@@ -653,6 +653,16 @@ go.lumeweb.com/portal v0.4.2-0.20250926221356-5ad0c2ded0a5 h1:2FsFp4jsSmkCHggtih
 go.lumeweb.com/portal v0.4.2-0.20250926221356-5ad0c2ded0a5/go.mod h1:jnt7XiFkYBSJZ0eZ/kApFEnl9gm+f40f0y/dtaccr0g=
 go.lumeweb.com/portal v0.4.2-0.20250926222741-4b692c1ae488 h1:RbbMa/BhLTMsmHMRDImt9FBkQ34oZrrgOElZNILrHKc=
 go.lumeweb.com/portal v0.4.2-0.20250926222741-4b692c1ae488/go.mod h1:jnt7XiFkYBSJZ0eZ/kApFEnl9gm+f40f0y/dtaccr0g=
+go.lumeweb.com/portal v0.4.2-0.20250927001310-e7e6b3e6dab6 h1:zvYZXTk5d2W/oWaghr8gQqh6awyMK/YwJI8++NHJj6I=
+go.lumeweb.com/portal v0.4.2-0.20250927001310-e7e6b3e6dab6/go.mod h1:jnt7XiFkYBSJZ0eZ/kApFEnl9gm+f40f0y/dtaccr0g=
+go.lumeweb.com/portal v0.4.2-0.20250927002208-831ef63d1053 h1:hK+N6CaZIlref4KYVSd5KfIkzOp20OQub7SlzasdZc4=
+go.lumeweb.com/portal v0.4.2-0.20250927002208-831ef63d1053/go.mod h1:jnt7XiFkYBSJZ0eZ/kApFEnl9gm+f40f0y/dtaccr0g=
+go.lumeweb.com/portal v0.4.2-0.20250927010916-d5cb32602dd3 h1:F4T2j/LtlTZLvhxZsfUK4vI7DzqqrSpULZ5pX7visRI=
+go.lumeweb.com/portal v0.4.2-0.20250927010916-d5cb32602dd3/go.mod h1:jnt7XiFkYBSJZ0eZ/kApFEnl9gm+f40f0y/dtaccr0g=
+go.lumeweb.com/portal v0.4.2-0.20250927012645-16d66ba4abd5 h1:vfLOVFhHS4NlQYYi4ZrNpo1EA1EVeXngfOGvKhFMIeU=
+go.lumeweb.com/portal v0.4.2-0.20250927012645-16d66ba4abd5/go.mod h1:jnt7XiFkYBSJZ0eZ/kApFEnl9gm+f40f0y/dtaccr0g=
+go.lumeweb.com/portal v0.4.2-0.20250927013046-41c69f1889b1 h1:Wfkaejba9GyOS58GZMTEJnhAvBLov5qYjD47MLyZgPE=
+go.lumeweb.com/portal v0.4.2-0.20250927013046-41c69f1889b1/go.mod h1:jnt7XiFkYBSJZ0eZ/kApFEnl9gm+f40f0y/dtaccr0g=
 go.lumeweb.com/portal-middleware v0.3.1 h1:XfYQPqCWFkUbyGa0nSbKlHYxZgs+jVdovkQusTACbBs=
 go.lumeweb.com/portal-middleware v0.3.1/go.mod h1:zxCrbMLGjhnzCl3lC/fFp3583/2eRLAsCiwnTrs+O48=
 go.lumeweb.com/portal-router v0.6.7 h1:aqdbZkEUXhuxQfWlMq8wWvDTZ90bjvqn6M84D3GJJBU=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -14,10 +14,11 @@ import (
 	"time"
 
 	"go.lumeweb.com/portal-middleware/middleware"
+	"go.lumeweb.com/portal/service"
 	_ "golang.org/x/image/webp"
 
 	"github.com/gorilla/sessions"
-	"github.com/labstack/echo/v4" // Import echo
+	"github.com/labstack/echo/v4"
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/gothic"
 	"github.com/samber/lo"
@@ -31,7 +32,7 @@ import (
 	pluginConfig "go.lumeweb.com/portal-plugin-dashboard/internal/config"
 	"go.lumeweb.com/portal-plugin-dashboard/internal/provider"
 	_ "go.lumeweb.com/portal-plugin-dashboard/internal/provider/providers"
-	"go.lumeweb.com/portal-plugin-dashboard/internal/service"
+	pluginService "go.lumeweb.com/portal-plugin-dashboard/internal/service"
 	router "go.lumeweb.com/portal-router"
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
@@ -51,17 +52,19 @@ const (
 var _ core.API = (*API)(nil)
 
 type API struct {
-	ctx        core.Context
-	config     config.Manager
-	user       core.UserService
-	auth       core.AuthService
-	password   core.PasswordResetService
-	otp        core.OTPService
-	apiKey     service.APIKeyService
-	access     core.AccessService
-	logger     *core.Logger
-	http       core.HTTPService
-	requestSvc core.RequestService
+	ctx         core.Context
+	config      config.Manager
+	user        core.UserService
+	auth        core.AuthService
+	password    core.PasswordResetService
+	otp         core.OTPService
+	apiKey      pluginService.APIKeyService
+	access      core.AccessService
+	logger      *core.Logger
+	http        core.HTTPService
+	requestSvc  core.RequestService
+	workflowSvc core.WorkflowService
+	ops         core.OperationFinder
 }
 
 func (a *API) OpenAPIInfo() router.APIInfoDefinition {
@@ -89,11 +92,13 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 			api.auth = ctx.Service(core.AUTH_SERVICE).(core.AuthService)
 			api.password = ctx.Service(core.PASSWORD_RESET_SERVICE).(core.PasswordResetService)
 			api.otp = ctx.Service(core.OTP_SERVICE).(core.OTPService)
-			api.apiKey = ctx.Service(service.API_KEY_SERVICE).(service.APIKeyService)
+			api.apiKey = ctx.Service(pluginService.API_KEY_SERVICE).(pluginService.APIKeyService)
 			api.access = ctx.Service(core.ACCESS_SERVICE).(core.AccessService)
 			api.logger = ctx.APILogger(api)
 			api.http = ctx.Service(core.HTTP_SERVICE).(core.HTTPService)
 			api.requestSvc = ctx.Service(core.REQUEST_SERVICE).(core.RequestService)
+			api.workflowSvc = ctx.Service(core.WORKFLOW_SERVICE).(core.WorkflowService)
+			api.ops = service.NewOperationFinder(ctx)
 
 			return nil
 		}),

--- a/internal/api/api_operation.go
+++ b/internal/api/api_operation.go
@@ -147,9 +147,6 @@ func (a *API) listOperations(c echo.Context) error {
 		return ctx.Error(core.NewAccountError(core.ErrKeyInvalidLogin, nil), http.StatusUnauthorized)
 	}
 
-	// Use workflow service instead of request service
-	workflowSvc := core.GetService[core.WorkflowService](a.ctx, core.WORKFLOW_SERVICE)
-
 	return queryutilHttp.ProcessListRequest(
 		c.Response(),
 		c.Request(),
@@ -157,7 +154,7 @@ func (a *API) listOperations(c echo.Context) error {
 		func(filters []queryutil.CrudFilter, sorts []queryutil.Sort, pagination queryutil.Pagination) ([]*dto.OperationListItem, int64, error) {
 			reqCtx := ctx.Request().Context()
 			// Use ListWorkflowInstances instead of GetRequests
-			instances, total, err := workflowSvc.ListWorkflowInstances(reqCtx, userID, filters, sorts, pagination)
+			instances, total, err := a.workflowSvc.ListWorkflowInstances(reqCtx, userID, filters, sorts, pagination)
 			if err != nil {
 				return nil, 0, err
 			}
@@ -165,7 +162,7 @@ func (a *API) listOperations(c echo.Context) error {
 			items := make([]*dto.OperationListItem, 0, len(instances))
 			for _, instance := range instances {
 				// Get workflow status for progress information
-				status, err := workflowSvc.GetWorkflowStatus(reqCtx, instance.Request.ID)
+				status, err := a.workflowSvc.GetWorkflowStatus(reqCtx, instance.Request.ID)
 				if err != nil {
 					// If we can't get status, use the request status
 					status = &core.WorkflowStatus{
@@ -205,11 +202,8 @@ func (a *API) getOperation(c echo.Context) error {
 		return nil // Error handled by DecodeAndValidateRequest
 	}
 
-	// Use workflow service instead of request service
-	workflowSvc := core.GetService[core.WorkflowService](a.ctx, core.WORKFLOW_SERVICE)
-
 	// Get workflow instance and verify ownership
-	instance, err := workflowSvc.GetWorkflowInstance(ctx.Request().Context(), userID, uint(paramDto.ID))
+	instance, err := a.workflowSvc.GetWorkflowInstance(ctx.Request().Context(), userID, uint(paramDto.ID))
 	if err != nil {
 		return ctx.Error(err, http.StatusNotFound)
 	}
@@ -217,7 +211,7 @@ func (a *API) getOperation(c echo.Context) error {
 	// instance should be non-nil here; if not, treat as not found upstream
 
 	// Get workflow status for detailed progress information
-	status, err := workflowSvc.GetWorkflowStatus(ctx.Request().Context(), instance.Request.ID)
+	status, err := a.workflowSvc.GetWorkflowStatus(ctx.Request().Context(), instance.Request.ID)
 	if err != nil {
 		// If we can't get status, use default values
 		status = &core.WorkflowStatus{
@@ -237,16 +231,17 @@ func (a *API) getOperationFilters(c echo.Context) error {
 		return ctx.Error(core.NewAccountError(core.ErrKeyInvalidLogin, nil), http.StatusUnauthorized)
 	}
 
-	// Use workflow service instead of request service
-	workflowSvc := core.GetService[core.WorkflowService](a.ctx, core.WORKFLOW_SERVICE)
-
 	// Get distinct filter values
-	filters, err := workflowSvc.ListDistinctWorkflowFilters(ctx.Request().Context(), userID, nil)
+	filters, err := a.workflowSvc.ListDistinctWorkflowFilters(ctx.Request().Context(), userID, nil)
 	if err != nil {
 		return ctx.Error(err, http.StatusInternalServerError)
 	}
 
-	response := &dto.OperationFiltersResponse{}
+	response := &dto.OperationFiltersResponse{
+		Statuses:   dto.GetStatusDisplayNames(filters[core.FilterRequestKeyStatuses]),
+		Operations: dto.GetOperationDisplayNames(a.ops, filters[core.FilterRequestKeyOperations]),
+		Protocols:  dto.GetProtocolDisplayNames(filters[core.FilterRequestKeyProtocols]),
+	}
 
 	return httputil.EncodeResponse(ctx, filters, response)
 }

--- a/internal/api/api_operation_test.go
+++ b/internal/api/api_operation_test.go
@@ -173,9 +173,9 @@ func TestGetOperationFilters_Success(t *testing.T) {
 		}
 
 		mockFilters := map[string][]string{
-			"status":    {"completed", "pending", "failed"},
-			"operation": {"upload", "pin"},
-			"protocol":  {"s3", "ipfs"},
+			core.FilterRequestKeyStatuses:   {"completed", "pending", "failed"},
+			core.FilterRequestKeyOperations: {"upload", "pin"},
+			core.FilterRequestKeyProtocols:  {"s3", "ipfs"},
 		}
 
 		// Mock expectations
@@ -209,23 +209,40 @@ func TestGetOperationFilters_Success(t *testing.T) {
 		assert.Len(tb, response.Protocols, 2)  // s3, ipfs
 
 		// Verify content includes expected values
-		expectedStatuses := []models.RequestStatusType{
-			models.RequestStatusCompleted,
-			models.RequestStatusPending,
-			models.RequestStatusFailed,
-		}
+		expectedStatuses := []string{"completed", "pending", "failed"}
 		for _, status := range expectedStatuses {
-			assert.Contains(tb, response.Statuses, status)
+			found := false
+			for _, item := range response.Statuses {
+				if item.Value == status {
+					found = true
+					break
+				}
+			}
+			assert.True(tb, found, "Status %s not found in response", status)
 		}
 
 		expectedOperations := []string{"upload", "pin"}
 		for _, operation := range expectedOperations {
-			assert.Contains(tb, response.Operations, operation)
+			found := false
+			for _, item := range response.Operations {
+				if item.Value == operation {
+					found = true
+					break
+				}
+			}
+			assert.True(tb, found, "Operation %s not found in response", operation)
 		}
 
 		expectedProtocols := []string{"s3", "ipfs"}
 		for _, protocol := range expectedProtocols {
-			assert.Contains(tb, response.Protocols, protocol)
+			found := false
+			for _, item := range response.Protocols {
+				if item.Value == protocol {
+					found = true
+					break
+				}
+			}
+			assert.True(tb, found, "Protocol %s not found in response", protocol)
 		}
 
 		// Verify mock expectations

--- a/internal/api/dto/operation.go
+++ b/internal/api/dto/operation.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/samber/lo"
 	"go.lumeweb.com/httputil"
+	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
 )
 
@@ -97,18 +98,77 @@ func (r *OperationDetailResponse) FromModel(model *OperationDetailResponse) erro
 }
 
 type OperationFiltersResponse struct {
-	Statuses   []models.RequestStatusType `json:"statuses"`
-	Operations []string                   `json:"operations"`
-	Protocols  []string                   `json:"protocols"`
+	Statuses   []OperationFilterItem `json:"statuses"`
+	Operations []OperationFilterItem `json:"operations"`
+	Protocols  []OperationFilterItem `json:"protocols"`
 }
 
-func (r *OperationFiltersResponse) FromModel(model map[string][]string) error {
-	r.Statuses = lo.Map(model["status"], func(s string, _ int) models.RequestStatusType {
-		return models.RequestStatusType(s)
-	})
-	r.Operations = model["operation"]
-	r.Protocols = model["protocol"]
+func (r *OperationFiltersResponse) FromModel(_ map[string][]string) error {
 	return nil
+}
+
+func GetOperationDisplayNames(finder core.OperationFinder, operationStrings []string) []OperationFilterItem {
+	return lo.Map(operationStrings, func(operation string, i int) OperationFilterItem {
+		handler, _, err := finder.FindOperationHandler(operation)
+		if err != nil {
+			// If we can't find the handler, use the operation string as the display name
+			return OperationFilterItem{
+				Value: operation,
+				Name:  operation,
+			}
+		}
+		name := core.GetOperationDisplayName(handler)
+
+		return OperationFilterItem{
+			Value: operation,
+			Name:  name,
+		}
+	})
+}
+
+func GetProtocolDisplayNames(protocolStrings []string) []OperationFilterItem {
+	// Get all registered protocols and create a map of names to display names
+	protocolList := core.GetProtocolList()
+	protocolDisplayMap := make(map[string]string)
+	for _, protocol := range protocolList {
+		protocolDisplayMap[protocol.Name()] = protocol.DisplayName()
+	}
+
+	return lo.Map(protocolStrings, func(protocol string, i int) OperationFilterItem {
+		name := protocol
+
+		// Check if we have a display name for this protocol
+		if displayName, exists := protocolDisplayMap[protocol]; exists {
+			name = displayName
+		}
+
+		return OperationFilterItem{
+			Value: protocol,
+			Name:  name,
+		}
+	})
+}
+
+func GetStatusDisplayNames(statusStrings []string) []OperationFilterItem {
+	return lo.Map(statusStrings, func(status string, i int) OperationFilterItem {
+		name := status
+
+		// Try to parse as models.RequestStatusType
+		statusType := models.RequestStatusType(status)
+		if displayInfo, exists := core.GetRequestStatusDisplayInfo(statusType); exists {
+			name = displayInfo.Name
+		}
+
+		return OperationFilterItem{
+			Value: status,
+			Name:  name,
+		}
+	})
+}
+
+type OperationFilterItem struct {
+	Value string `json:"value"`
+	Name  string `json:"name"`
 }
 
 // WebSocket event structure for operations


### PR DESCRIPTION
- Updated API struct to use workflow service instead of request service
- Modified listOperations and getOperation endpoints to utilize workflow service methods
- Adjusted operation filters response to include display names for statuses, operations, and protocols
- Updated tests to reflect changes in filter keys and response structure