### PR TITLE
refactor(api): wrap operation filters response with queryutil and set Content-Range header

### DIFF
--- a/internal/api/api_operation.go
+++ b/internal/api/api_operation.go
@@ -161,7 +161,7 @@ func (a *API) buildOperationRoutes(authMw echo.MiddlewareFunc, accessMw echo.Mid
 				router.WithSummary("Get Operation Filters"),
 				router.WithDescription("Retrieves distinct filter values for operations (statuses, operations, protocols)"),
 				router.WithSuccessResponse(http.StatusOK, "Distinct filter values for operations",
-					router.WithJSONContent(dto.OperationFiltersResponse{}),
+					router.WithJSONContent(queryutil.Response[*dto.OperationFiltersResponse]{}),
 				),
 			),
 			router.WithAccess(core.ACCESS_USER_ROLE),
@@ -285,7 +285,14 @@ func (a *API) getOperationFilters(c echo.Context) error {
 		Protocols:  dto.GetProtocolDisplayNames(filters[core.FilterRequestKeyProtocols]),
 	}
 
-	return httputil.EncodeResponse(ctx, filters, response)
+	// Set Content-Range header (using empty pagination since this is a single item)
+	queryutilHttp.SetContentRangeHeader(c.Response(), "filters", queryutil.Pagination{}, []*dto.OperationFiltersResponse{response}, 1)
+
+	// Build response using queryutil.BuildResponse
+	wrappedResponse := queryutil.BuildResponse[*dto.OperationFiltersResponse](response, 1)
+
+	// Encode response using queryutilHttp.EncodeJSON
+	return queryutilHttp.EncodeJSON(c.Response(), wrappedResponse)
 }
 
 func (a *API) wsOperations(c echo.Context) error {


### PR DESCRIPTION
*   Changed the success response type for the "Get Operation Filters" endpoint from `dto.OperationFiltersResponse` to `queryutil.Response[*dto.OperationFiltersResponse]`.
*   Updated `getOperationFilters` handler to use `queryutilHttp.SetContentRangeHeader` and `queryutil.BuildResponse` for consistent response formatting.
*   Replaced `httputil.EncodeResponse` with `queryutilHttp.EncodeJSON` for encoding the wrapped response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - The /api/operations/filters endpoint now returns data in a standardized JSON envelope for consistent responses.
  - Adds a Content-Range header to single-item responses to provide uniform pagination metadata.
  - JSON encoding aligned with the standardized response format.

- Chores
  - Route metadata updated to reflect the new wrapped response structure.

Note: API clients should update parsing to accommodate the wrapped response format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->