### PR TITLE
refactor(api): wrap operation filters response data in a dedicated struct

### DIFF
--- a/internal/api/api_operation.go
+++ b/internal/api/api_operation.go
@@ -280,19 +280,15 @@ func (a *API) getOperationFilters(c echo.Context) error {
 	}
 
 	response := &dto.OperationFiltersResponse{
-		Statuses:   dto.GetStatusDisplayNames(filters[core.FilterRequestKeyStatuses]),
-		Operations: dto.GetOperationDisplayNames(a.ops, filters[core.FilterRequestKeyOperations]),
-		Protocols:  dto.GetProtocolDisplayNames(filters[core.FilterRequestKeyProtocols]),
+		Data: dto.OperationFiltersResponseData{
+			Statuses:   dto.GetStatusDisplayNames(filters[core.FilterRequestKeyStatuses]),
+			Operations: dto.GetOperationDisplayNames(a.ops, filters[core.FilterRequestKeyOperations]),
+			Protocols:  dto.GetProtocolDisplayNames(filters[core.FilterRequestKeyProtocols]),
+		},
 	}
 
-	// Set Content-Range header (using empty pagination since this is a single item)
-	queryutilHttp.SetContentRangeHeader(c.Response(), "filters", queryutil.Pagination{}, []*dto.OperationFiltersResponse{response}, 1)
-
-	// Build response using queryutil.BuildResponse
-	wrappedResponse := queryutil.BuildResponse[*dto.OperationFiltersResponse](response, 1)
-
 	// Encode response using queryutilHttp.EncodeJSON
-	return queryutilHttp.EncodeJSON(c.Response(), wrappedResponse)
+	return queryutilHttp.EncodeJSON(c.Response(), response)
 }
 
 func (a *API) wsOperations(c echo.Context) error {

--- a/internal/api/dto/operation.go
+++ b/internal/api/dto/operation.go
@@ -110,6 +110,10 @@ func (r *OperationDetailResponse) FromModel(model *OperationDetailResponse) erro
 }
 
 type OperationFiltersResponse struct {
+	Data OperationFiltersResponseData `json:"data"`
+}
+
+type OperationFiltersResponseData struct {
 	Statuses   []OperationFilterItem `json:"statuses"`
 	Operations []OperationFilterItem `json:"operations"`
 	Protocols  []OperationFilterItem `json:"protocols"`


### PR DESCRIPTION
- Modified `OperationFiltersResponse` to include a `Data` field of type `OperationFiltersResponseData`
- Updated `getOperationFilters` to populate the new nested structure
- Removed unnecessary pagination and wrapping logic for filter response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Breaking Changes
  - Operation Filters API response now nests fields under a single data object (containing statuses, operations, and protocols). Update clients to parse from response.data.
  - Content-Range header is no longer included in this endpoint’s responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->