### PR TITLE
refactor(api): change CID field type from *cid.Cid to *string in operation DTOs

### DIFF
--- a/internal/api/api_operation.go
+++ b/internal/api/api_operation.go
@@ -23,10 +23,11 @@ func (a *API) convertWorkflowInstanceToOperationListItem(instance *core.Workflow
 	}
 
 	// Create CID pointer if hash exists
-	var cidPtr *cid.Cid
+	var cidPtr *string
 	if instance.Request.Hash != nil {
 		cidVal := cid.NewCidV1(instance.Request.CIDType, instance.Request.Hash)
-		cidPtr = &cidVal
+		cidStr := cidVal.String()
+		cidPtr = &cidStr
 	}
 
 	// Create step pointers
@@ -79,10 +80,11 @@ func (a *API) convertWorkflowInstanceToOperationDetailResponse(instance *core.Wo
 	}
 
 	// Create CID pointer if hash exists
-	var cidPtr *cid.Cid
+	var cidPtr *string
 	if instance.Request.Hash != nil {
 		cidVal := cid.NewCidV1(instance.Request.CIDType, instance.Request.Hash)
-		cidPtr = &cidVal
+		cidStr := cidVal.String()
+		cidPtr = &cidStr
 	}
 
 	// Create step pointers if values are meaningful

--- a/internal/api/dto/operation.go
+++ b/internal/api/dto/operation.go
@@ -44,7 +44,7 @@ type OperationListItem struct {
 	StartedAt             time.Time                `json:"started_at" filter:"true" sort:"true"`
 	UpdatedAt             time.Time                `json:"updated_at" filter:"true" sort:"true"`
 	EstimatedCompletionAt *time.Time               `json:"estimated_completion_at,omitempty" filter:"true" sort:"true"`
-	CID                   *cid.Cid                 `json:"cid,omitempty" filter:"true" sort:"true"`
+	CID                   *string                  `json:"cid,omitempty" filter:"true" sort:"true"`
 	TotalSteps            *int64                   `json:"total_steps,omitempty" filter:"true" sort:"true"`
 	CurrentStep           *int64                   `json:"current_step,omitempty" filter:"true" sort:"true"`
 	Error                 *string                  `json:"error,omitempty" filter:"true" sort:"true"`
@@ -83,7 +83,7 @@ type OperationDetailResponse struct {
 	StartedAt             time.Time                `json:"started_at"`
 	UpdatedAt             time.Time                `json:"updated_at"`
 	EstimatedCompletionAt *time.Time               `json:"estimated_completion_at,omitempty"`
-	CID                   *cid.Cid                 `json:"cid,omitempty"`
+	CID                   *string                  `json:"cid,omitempty"`
 	TotalSteps            *int64                   `json:"total_steps,omitempty"`
 	CurrentStep           *int64                   `json:"current_step,omitempty"`
 	Error                 *string                  `json:"error,omitempty"`
@@ -221,7 +221,7 @@ type OperationEventPayload struct {
 	StatusMessage         *string                   `json:"status_message,omitempty"`
 	EstimatedCompletionAt *time.Time                `json:"estimated_completion_at,omitempty"`
 	Error                 *string                   `json:"error,omitempty"`
-	CID                   *cid.Cid                  `json:"cid,omitempty"`
+	CID                   *string                   `json:"cid,omitempty"`
 	TotalSteps            *int64                    `json:"total_steps,omitempty"`
 	CurrentStep           *int64                    `json:"current_step,omitempty"`
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized CID values in operation-related API responses to be returned as strings instead of complex objects. This applies to operation list items, operation detail responses, and operation event payloads. Clients should expect CID fields as string pointers and update parsing accordingly. This change improves interoperability with tools and languages that handle string-based identifiers more reliably and simplifies client-side handling of CID values across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->