### PR TITLE
refactor: extract plugin info retrieval into separate method

### DIFF
--- a/.git-town.toml
+++ b/.git-town.toml
@@ -1,0 +1,4 @@
+# See https://www.git-town.com/configuration-file for details
+
+[branches]
+main = "develop"

--- a/dashboard.go
+++ b/dashboard.go
@@ -23,13 +23,13 @@ var mailerTemplates embed.FS
 
 type APIConfig = pluginConfig.APIConfig
 
-func init() {
+func GetPluginInfo() core.PluginInfo {
 	templates, err := service.MailerTemplatesFromEmbed(&mailerTemplates, "")
 	if err != nil {
 		panic(err)
 	}
 
-	core.RegisterPlugin(core.PluginInfo{
+	return core.PluginInfo{
 		ID:      internal.PLUGIN_NAME,
 		Version: build.GetInfo(),
 		Depends: []string{"core"},
@@ -75,5 +75,9 @@ func init() {
 		},
 		MailerTemplates: templates,
 		WebBundles:      core.NewWebBundles(core.NewWebBundle(portal_plugin_dashboard.GetFS(), core.WithWebBundleTargetApps("dashboard"))),
-	})
+	}
+}
+
+func init() {
+	core.RegisterPlugin(GetPluginInfo())
 }


### PR DESCRIPTION
- Moved plugin info construction to `GetPluginInfo()` method
- Maintains same plugin registration behavior in init()
- Improves code organization and separation of concerns


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored plugin registration structure for improved maintainability.

* **Chores**
  * Added git-town configuration for branch mapping.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->