### PR TITLE
fix(core): move API_KEY_SERVICE constant to core package

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -7,6 +7,8 @@ import (
 	"go.lumeweb.com/queryutil"
 )
 
+const API_KEY_SERVICE = "api_key"
+
 type APIKeyService interface {
 	core.Service
 	CreateAPIKey(userID uint, name string) (*models.APIKey, error)

--- a/dashboard.go
+++ b/dashboard.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"go.lumeweb.com/portal-plugin-dashboard/build"
+	pluginCore "go.lumeweb.com/portal-plugin-dashboard/core"
 	"go.lumeweb.com/portal-plugin-dashboard/internal"
 	"go.lumeweb.com/portal-plugin-dashboard/internal/api"
 	pluginConfig "go.lumeweb.com/portal-plugin-dashboard/internal/config"
@@ -57,7 +58,7 @@ func GetPluginInfo() core.PluginInfo {
 		Services: func() ([]core.ServiceInfo, error) {
 			return []core.ServiceInfo{
 				{
-					ID: apiKeyService.API_KEY_SERVICE,
+					ID: pluginCore.API_KEY_SERVICE,
 					Factory: func() (core.Service, []core.ContextBuilderOption, error) {
 						return apiKeyService.NewAPIKeyService()
 					},

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -15,7 +15,6 @@ import (
 
 	"go.lumeweb.com/portal-middleware/middleware"
 	pluginCore "go.lumeweb.com/portal-plugin-dashboard/core"
-	apiKeyService "go.lumeweb.com/portal-plugin-dashboard/internal/service/api_key"
 	"go.lumeweb.com/portal/service"
 	_ "golang.org/x/image/webp"
 
@@ -93,7 +92,7 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 			api.auth = ctx.Service(core.AUTH_SERVICE).(core.AuthService)
 			api.password = ctx.Service(core.PASSWORD_RESET_SERVICE).(core.PasswordResetService)
 			api.otp = ctx.Service(core.OTP_SERVICE).(core.OTPService)
-			api.apiKey = ctx.Service(apiKeyService.API_KEY_SERVICE).(pluginCore.APIKeyService)
+			api.apiKey = ctx.Service(pluginCore.API_KEY_SERVICE).(pluginCore.APIKeyService)
 			api.access = ctx.Service(core.ACCESS_SERVICE).(core.AccessService)
 			api.logger = ctx.APILogger(api)
 			api.http = ctx.Service(core.HTTP_SERVICE).(core.HTTPService)

--- a/internal/service/api_key/api_key.go
+++ b/internal/service/api_key/api_key.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"go.lumeweb.com/portal-middleware/auth/jwt"
+	pluginCore "go.lumeweb.com/portal-plugin-dashboard/core"
 	pluginDb "go.lumeweb.com/portal-plugin-dashboard/internal/db/models"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db"
@@ -15,8 +16,6 @@ import (
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
-
-const API_KEY_SERVICE = "api_key"
 
 var (
 	PurposeAPI jwt.Purpose = "api"
@@ -47,7 +46,7 @@ func NewAPIKeyService() (core.Service, []core.ContextBuilderOption, error) {
 }
 
 func (s *APIKeyServiceDefault) ID() string {
-	return API_KEY_SERVICE
+	return pluginCore.API_KEY_SERVICE
 }
 
 func (s *APIKeyServiceDefault) CreateAPIKey(userID uint, name string) (*pluginDb.APIKey, error) {


### PR DESCRIPTION
- Centralized the `API_KEY_SERVICE` constant in `pluginCore` instead of defining it in both `core/core.go` and `internal/service/api_key/api_key.go`
- Updated all references to use the shared constant from the core package
- Removed duplicate constant definition in service implementation
- Ensued consistent service ID across the codebase


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced API key management capabilities, including retrieval with filtering, sorting, and pagination options.
  * Added functionality to delete and validate API keys.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->