### PR TITLE
refactor(api): remove access control from upload limit endpoint

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -482,8 +482,6 @@ func (a *API) Configure(gRouter router.Router, accessSvc core.AccessService) err
 			router.WithDescription("Retrieves the maximum allowed upload size."),
 			router.WithResponseHeaders(http.StatusOK, "Upload limit", map[string]swagger.Schema{"application/json": {Value: dto.UploadLimitResponse{}}}, nil),
 		),
-		router.WithAccess(core.ACCESS_USER_ROLE),
-		router.WithMiddlewares(authMw, accessMw),
 	))
 
 	if err := router.RegisterRoutes(gRouter, accessSvc, a.Subdomain(), routes, router.WithCors()); err != nil {


### PR DESCRIPTION
- Removed `router.WithAccess(core.ACCESS_USER_ROLE)` restriction
- Removed authentication and authorization middleware
- Makes the upload limit endpoint publicly accessible


---

<!-- kody-pr-summary:start -->
Removes access control and authentication middleware from the endpoint responsible for retrieving the maximum allowed upload size. This change makes the upload limit information publicly accessible without requiring a user role or authentication.
<!-- kody-pr-summary:end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Removed authentication and access control requirements from the `/api/upload-limit` endpoint, making it publicly accessible.

- Removed `router.WithAccess(core.ACCESS_USER_ROLE)` restriction
- Removed `authMw` and `accessMw` middleware from the endpoint configuration
- The endpoint now returns the configured `PostUploadLimit` value without requiring authentication
- Aligns with other public endpoints like `/api/auth/register`, `/api/auth/login`, and `/api/auth/logout` which use `router.WithAccess("")`
- The upload limit is a read-only configuration value that doesn't expose sensitive user data

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change makes a read-only configuration endpoint publicly accessible, which is appropriate since clients need to know the upload limit before attempting uploads. The endpoint returns only a single configuration value (`PostUploadLimit`) and doesn't expose sensitive data or enable any privileged operations. This pattern aligns with other public endpoints in the codebase.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/api/api.go | removed authentication/access control from upload limit endpoint, making it publicly accessible |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API as /api/upload-limit
    participant Config as Configuration

    Note over Client,Config: Before: Authenticated Access
    Client->>API: GET /api/upload-limit (with auth token)
    API->>API: authMw: Verify JWT
    API->>API: accessMw: Check ACCESS_USER_ROLE
    API->>Config: Get PostUploadLimit
    Config-->>API: Return limit value
    API-->>Client: {"limit": 123456}

    Note over Client,Config: After: Public Access
    Client->>API: GET /api/upload-limit (no auth required)
    API->>Config: Get PostUploadLimit
    Config-->>API: Return limit value
    API-->>Client: {"limit": 123456}
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->