### PR TITLE
fix(api): add concrete DTOs for swagger documentation to fix generic type detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	go.lumeweb.com/httputil v0.5.3
 	go.lumeweb.com/portal v0.4.2-0.20251227025518-975cf612867e
 	go.lumeweb.com/portal-middleware v0.3.4
-	go.lumeweb.com/portal-router v0.6.9
+	go.lumeweb.com/portal-router v0.6.10
 	go.lumeweb.com/queryutil v0.3.15
 	go.lumeweb.com/web/go/portal-dashboard v0.0.0-20251007105956-9515ed1f2355
 	go.lumeweb.com/web/go/portal-plugin-dashboard v0.0.0-20251007105956-9515ed1f2355

--- a/go.sum
+++ b/go.sum
@@ -817,6 +817,8 @@ go.lumeweb.com/portal-middleware v0.3.4 h1:A9/Ipo3giX449CCgbKGco97IqDxFG7Z1ppmM1
 go.lumeweb.com/portal-middleware v0.3.4/go.mod h1:3dHvOYXApc1b673I1UAoYBpyXg2c7ku4HqxXvef8dj8=
 go.lumeweb.com/portal-router v0.6.9 h1:jJsYdb1aUrroEjQ+CtJ9j6k3Jn7BmOAgPhpm1UkSAAM=
 go.lumeweb.com/portal-router v0.6.9/go.mod h1:4tb+XYa0GYiFVraMoossGgMBTN9z4U54v8SL+EOBvbs=
+go.lumeweb.com/portal-router v0.6.10 h1:JIiiahazddFsKyuwidymaka/9uWW3NaaMAT5xzSYo3U=
+go.lumeweb.com/portal-router v0.6.10/go.mod h1:4tb+XYa0GYiFVraMoossGgMBTN9z4U54v8SL+EOBvbs=
 go.lumeweb.com/queryutil v0.3.15 h1:R2l6GAAne8rCgh1rGy5HQ54zvs8JJw3gRLjhmkd8SHk=
 go.lumeweb.com/queryutil v0.3.15/go.mod h1:nLkIuXzugX8Ln24wsAbfTafvNmaTHLJhIUKWC1693G4=
 go.lumeweb.com/web/go/portal-dashboard v0.0.0-20251007105956-9515ed1f2355 h1:eQQaAwefoLF36w2Su31bXJS9GVMEnZ+NKqtiz2MaEeU=

--- a/internal/api/api_keys.go
+++ b/internal/api/api_keys.go
@@ -24,6 +24,9 @@ import (
 )
 
 func (a *API) buildAPIKeyRoutes(authMw echo.MiddlewareFunc, accessMw echo.MiddlewareFunc) []router.Route {
+	schemaProvider := queryutil.NewSchemaProvider()
+	keysSchema := schemaProvider.ForType(dto.APIKeyFilterRequest{})
+
 	return []router.Route{
 		router.NewRoute(http.MethodPost, "/api/account/keys", a.createAPIKey,
 			router.WithSwaggerOptions(
@@ -40,6 +43,8 @@ func (a *API) buildAPIKeyRoutes(authMw echo.MiddlewareFunc, accessMw echo.Middle
 				router.WithSummary("List API Keys"),
 				router.WithDescription("Retrieves a list of API keys for the authenticated user."),
 				router.WithPaginationParams(),
+				router.WithSortParams(keysSchema.SortableFields()),
+				router.WithFilterParamsFromSchema(keysSchema),
 				router.WithSuccessResponse(http.StatusOK, "List of API Keys",
 					router.WithJSONContent(dto.APIKeyListResponse{}),
 					router.WithTotalCountHeader(),

--- a/internal/api/api_keys.go
+++ b/internal/api/api_keys.go
@@ -40,11 +40,10 @@ func (a *API) buildAPIKeyRoutes(authMw echo.MiddlewareFunc, accessMw echo.Middle
 				router.WithSummary("List API Keys"),
 				router.WithDescription("Retrieves a list of API keys for the authenticated user."),
 				router.WithPaginationParams(),
-				router.WithResponseHeaders(http.StatusOK, "List of API Keys", map[string]swagger.Schema{
-					"application/json": {
-						Value: queryutil.Response[*dto.APIKeyResponse]{},
-					},
-				}, nil),
+				router.WithSuccessResponse(http.StatusOK, "List of API Keys",
+					router.WithJSONContent(dto.APIKeyListResponse{}),
+					router.WithTotalCountHeader(),
+				),
 			),
 			router.WithAccess(core.ACCESS_USER_ROLE),
 			router.WithMiddlewares(authMw, accessMw),

--- a/internal/api/api_operation.go
+++ b/internal/api/api_operation.go
@@ -138,7 +138,8 @@ func (a *API) convertWorkflowInstanceToOperationDetailResponse(instance *core.Wo
 
 func (a *API) buildOperationRoutes(authMw echo.MiddlewareFunc, accessMw echo.MiddlewareFunc) []router.Route {
 	schemaProvider := queryutil.NewSchemaProvider()
-	operationSchema := schemaProvider.ForType(dto.OperationListItem{})
+	operationSchema := schemaProvider.ForType(dto.OperationFilterRequest{})
+	operationListSchema := schemaProvider.ForType(dto.OperationListItem{})
 
 	return []router.Route{
 		router.NewRoute(http.MethodGet, "/api/operations", a.listOperations,
@@ -147,11 +148,10 @@ func (a *API) buildOperationRoutes(authMw echo.MiddlewareFunc, accessMw echo.Mid
 				router.WithDescription("Retrieve a list of operations, with filtering, searching, and pagination support."),
 				router.WithQueryParam("search", "Search term for filename or other relevant operation data", ""),
 				router.WithPaginationParams(),
-				router.WithSortParams(operationSchema.SortableFields()),
-				//  TODO: Fix panic on processing schemas with pointers?
-				//	router.WithFilterParamsFromSchema(operationSchema),
+				router.WithSortParams(operationListSchema.SortableFields()),
+				router.WithFilterParamsFromSchema(operationSchema),
 				router.WithSuccessResponse(http.StatusOK, "A list of operations",
-					router.WithJSONContent(queryutil.Response[*dto.OperationListItem]{}),
+					router.WithJSONContent(dto.OperationListItemResponse{}),
 					router.WithTotalCountHeader(),
 				),
 			),

--- a/internal/api/dto/operation.go
+++ b/internal/api/dto/operation.go
@@ -20,6 +20,13 @@ type OperationRequest struct {
 	ID uint64 `param:"id" zog:"required"`
 }
 
+type OperationFilterRequest struct {
+	ID              uint64  `json:"id" filter:"true"`
+	Operation       string  `json:"operation" filter:"true"`
+	ProgressPercent float64 `json:"progress_percent" filter:"true"`
+	CID             string  `json:"cid" filter:"true"`
+}
+
 func (r *OperationRequest) Schema() *z.StructSchema {
 	return z.Struct(z.Shape{
 		"ID": z.UintLike[uint64]().Required(),
@@ -223,4 +230,17 @@ type OperationEventPayload struct {
 	CID                   *string                   `json:"cid,omitempty"`
 	TotalSteps            *int64                    `json:"total_steps,omitempty"`
 	CurrentStep           *int64                    `json:"current_step,omitempty"`
+}
+
+// OperationListItemResponse is a swagger-only DTO that represents the paginated response for operations.
+// It merges the generic queryutil.Response[*dto.OperationListItem] for OpenAPI documentation.
+//
+// This struct exists due to a TODO bug where queryutil.Response generics are not getting detected
+// properly as an array type in the swagger documentation generation. By providing a concrete struct,
+// we ensure the swagger docs correctly show the data field as an array of OperationListItem items.
+//
+// Note: This struct is only used for swagger documentation, not for actual encoding.
+type OperationListItemResponse struct {
+	Data  []OperationListItem `json:"data"`
+	Total int64               `json:"total"`
 }

--- a/internal/api/dto/response.go
+++ b/internal/api/dto/response.go
@@ -27,6 +27,10 @@ type APIKeyCreateRequest struct {
 	Name string `json:"name"`
 }
 
+type APIKeyFilterRequest struct {
+	Name string `json:"name" filter:"true"`
+}
+
 type UpdateProfileRequest struct {
 	FirstName *string `json:"first_name,omitempty"`
 	LastName  *string `json:"last_name,omitempty"`

--- a/internal/api/dto/response.go
+++ b/internal/api/dto/response.go
@@ -101,6 +101,19 @@ type APIKeyResponse struct {
 	CreatedAt time.Time        `json:"created_at"`
 }
 
+// APIKeyListResponse is a swagger-only DTO that represents the paginated response for API keys.
+// It merges the generic queryutil.Response[*dto.APIKeyResponse] for OpenAPI documentation.
+//
+// This struct exists due to a TODO bug where queryutil.Response generics are not getting detected
+// properly as an array type in the swagger documentation generation. By providing a concrete struct,
+// we ensure the swagger docs correctly show the data field as an array of APIKeyResponse items.
+//
+// Note: This struct is only used for swagger documentation, not for actual encoding.
+type APIKeyListResponse struct {
+	Data  []APIKeyResponse `json:"data"`
+	Total int64            `json:"total"`
+}
+
 func (r *APIKeyResponse) FromModel(key *pluginDb.APIKey) error {
 	r.UUID = key.UUID
 	r.Name = key.Name


### PR DESCRIPTION
- Add `APIKeyListResponse` DTO to replace generic `queryutil.Response[*dto.APIKeyResponse]`
- Add `OperationListItemResponse` DTO to replace generic `queryutil.Response[*dto.OperationListItem]`
- Add `OperationFilterRequest` DTO for operation filtering
- Update swagger route definitions to use new concrete response types
- Enable filter params for operations endpoint

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes OpenAPI documentation generation by replacing generic `queryutil.Response` types with concrete DTOs. The swagger generation system was not properly detecting generic types as arrays, causing incorrect API documentation.

**Key Changes:**
- Added `APIKeyListResponse` and `OperationListItemResponse` concrete DTOs that replicate the structure of `queryutil.Response[T]`
- Added `OperationFilterRequest` DTO to define filterable fields for the operations endpoint
- Updated swagger route definitions to use concrete response types instead of generics
- Enabled filter parameters for the operations endpoint (previously commented out due to the generic type detection issue)
- Bumped `portal-router` dependency to v0.6.10

**Impact:**
The changes are purely cosmetic for OpenAPI documentation and don't affect runtime behavior. The actual HTTP responses continue to be generated by `queryutil.ProcessListRequest`, which uses the generic `Response[T]` type. The new concrete DTOs are marked as "swagger-only" and are used exclusively for documentation generation.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk - it only affects API documentation generation
- The changes are documentation-only and don't modify runtime behavior. The new DTOs replicate existing generic structures, filter fields are properly tagged, and the dependency bump is minor. All changes follow existing patterns and maintain backward compatibility.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/api/api_keys.go | Replaced generic swagger response with concrete `dto.APIKeyListResponse` for better OpenAPI documentation |
| internal/api/api_operation.go | Added `OperationFilterRequest` schema for filtering, enabled filter params, and replaced generic response with concrete `dto.OperationListItemResponse` |
| internal/api/dto/operation.go | Added `OperationFilterRequest` DTO with filter fields and `OperationListItemResponse` concrete type for swagger documentation |
| internal/api/dto/response.go | Added `APIKeyListResponse` concrete type to replace generic response for swagger documentation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Router as portal-router v0.6.10
    participant API as API Handler
    participant DTO as DTO Layer
    participant Swagger as OpenAPI Spec

    Note over Client,Swagger: API Keys Endpoint Flow
    Client->>Router: GET /api/account/keys
    Router->>API: getAPIKeys()
    API->>API: Validate user authentication
    API->>API: ProcessListRequest with filters/pagination
    API->>DTO: Map to APIKeyResponse[]
    Note over DTO: Uses concrete APIKeyListResponse<br/>instead of generic Response type
    DTO->>Router: Return paginated response
    Router->>Client: JSON response with data & total

    Note over Client,Swagger: Operations Endpoint Flow
    Client->>Router: GET /api/operations?filter[operation]=upload
    Router->>API: listOperations()
    API->>API: Validate user authentication
    API->>API: Parse OperationFilterRequest schema
    Note over API: Filter params now enabled<br/>via WithFilterParamsFromSchema
    API->>API: ProcessListRequest with filters/sorts/pagination
    API->>DTO: Map to OperationListItem[]
    Note over DTO: Uses concrete OperationListItemResponse<br/>instead of generic Response type
    DTO->>Router: Return paginated response
    Router->>Client: JSON response with data & total

    Note over Router,Swagger: Swagger Documentation Generation
    Router->>Swagger: Generate OpenAPI spec
    Note over Swagger: Concrete DTOs correctly detected<br/>as array types (fixes generic bug)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

---

<!-- kody-pr-summary:start -->
This pull request introduces specific Data Transfer Objects (DTOs) to improve the accuracy of Swagger/OpenAPI documentation for list endpoints and enables filtering for operations.

Key changes include:

*   **Improved Swagger Documentation for List Endpoints**:
    *   Introduced `APIKeyListResponse` and `OperationListItemResponse` DTOs. These concrete DTOs replace generic `queryutil.Response` types in the Swagger documentation generation for the "List API Keys" and "List Operations" endpoints. This resolves an issue where generic types were not correctly detected as array types in the generated OpenAPI specification, ensuring the `data` field is properly displayed as an array of items.
*   **Enabled Filtering for Operations**:
    *   Added `OperationFilterRequest` DTO, which defines the fields available for filtering operations.
    *   Integrated this DTO to enable filtering capabilities for the `/api/operations` endpoint in the API documentation.
*   **Corrected Operation Sorting Parameters**:
    *   Adjusted the sorting parameters for the "List Operations" endpoint to use the correct schema (`OperationListItem`) for defining sortable fields.
<!-- kody-pr-summary:end -->