### PR TITLE
fix(api-keys): use custom stringUUIDSchema for keyID path parameter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	go.lumeweb.com/httputil v0.5.3
 	go.lumeweb.com/portal v0.4.2-0.20251227025518-975cf612867e
 	go.lumeweb.com/portal-middleware v0.3.4
-	go.lumeweb.com/portal-router v0.6.10
+	go.lumeweb.com/portal-router v0.6.11
 	go.lumeweb.com/queryutil v0.3.15
 	go.lumeweb.com/web/go/portal-dashboard v0.0.0-20251007105956-9515ed1f2355
 	go.lumeweb.com/web/go/portal-plugin-dashboard v0.0.0-20251007105956-9515ed1f2355

--- a/go.sum
+++ b/go.sum
@@ -819,6 +819,8 @@ go.lumeweb.com/portal-router v0.6.9 h1:jJsYdb1aUrroEjQ+CtJ9j6k3Jn7BmOAgPhpm1UkSA
 go.lumeweb.com/portal-router v0.6.9/go.mod h1:4tb+XYa0GYiFVraMoossGgMBTN9z4U54v8SL+EOBvbs=
 go.lumeweb.com/portal-router v0.6.10 h1:JIiiahazddFsKyuwidymaka/9uWW3NaaMAT5xzSYo3U=
 go.lumeweb.com/portal-router v0.6.10/go.mod h1:4tb+XYa0GYiFVraMoossGgMBTN9z4U54v8SL+EOBvbs=
+go.lumeweb.com/portal-router v0.6.11 h1:0PTej57mtNcRpKZNukD0j0ZYp5ntbR7fl5g6DO+0mvk=
+go.lumeweb.com/portal-router v0.6.11/go.mod h1:4tb+XYa0GYiFVraMoossGgMBTN9z4U54v8SL+EOBvbs=
 go.lumeweb.com/queryutil v0.3.15 h1:R2l6GAAne8rCgh1rGy5HQ54zvs8JJw3gRLjhmkd8SHk=
 go.lumeweb.com/queryutil v0.3.15/go.mod h1:nLkIuXzugX8Ln24wsAbfTafvNmaTHLJhIUKWC1693G4=
 go.lumeweb.com/web/go/portal-dashboard v0.0.0-20251007105956-9515ed1f2355 h1:eQQaAwefoLF36w2Su31bXJS9GVMEnZ+NKqtiz2MaEeU=

--- a/internal/api/api_keys.go
+++ b/internal/api/api_keys.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	jsonschema "github.com/invopop/jsonschema"
 	"github.com/labstack/echo/v4"
 	swagger "go.lumeweb.com/gswagger"
 	"go.lumeweb.com/httputil"
@@ -22,6 +23,16 @@ import (
 	queryutilHttp "go.lumeweb.com/queryutil/http"
 	"gorm.io/gorm"
 )
+
+// stringUUIDSchema represents a UUID string for swagger schema generation
+type stringUUIDSchema string
+
+func (s stringUUIDSchema) JSONSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type:   "string",
+		Format: "uuid",
+	}
+}
 
 func (a *API) buildAPIKeyRoutes(authMw echo.MiddlewareFunc, accessMw echo.MiddlewareFunc) []router.Route {
 	schemaProvider := queryutil.NewSchemaProvider()
@@ -57,7 +68,7 @@ func (a *API) buildAPIKeyRoutes(authMw echo.MiddlewareFunc, accessMw echo.Middle
 			router.WithSwaggerOptions(
 				router.WithSummary("Delete API Key"),
 				router.WithDescription("Deletes a specific API key for the authenticated user."),
-				router.WithPathParam("keyID", "The UUID of the API key to delete", uuid.Nil),
+				router.WithPathParam("keyID", "The UUID of the API key to delete", stringUUIDSchema("")),
 				router.WithResponseHeaders(http.StatusOK, "API Key deleted", nil, nil),
 			),
 			router.WithAccess(core.ACCESS_USER_ROLE),


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Refactor: Improve Swagger documentation for API key ID path parameter

This pull request introduces a custom `stringUUIDSchema` type to explicitly define UUID string formatting within the generated Swagger/OpenAPI documentation.

Specifically, it updates the "Delete API Key" endpoint to use this new `stringUUIDSchema` for the `keyID` path parameter. This ensures that the API documentation accurately represents the `keyID` as a string with a UUID format, enhancing clarity and correctness for API consumers.
<!-- kody-pr-summary:end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes the Swagger documentation for the API key deletion endpoint by replacing `uuid.Nil` with a custom `stringUUIDSchema` type that properly implements the JSONSchema interface. The previous implementation using `uuid.Nil` likely generated incorrect OpenAPI schema for the UUID path parameter.

Key changes:
- Added `stringUUIDSchema` type with `JSONSchema()` method that returns proper UUID format specification
- Updated `router.WithPathParam` call to use `stringUUIDSchema("")` instead of `uuid.Nil`
- Bumped `portal-router` dependency to v0.6.11

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a focused bug fix that improves Swagger documentation generation. The custom type implementation follows standard patterns for JSONSchema generation, and the dependency bump is minor. No logical changes to the actual API key deletion behavior.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/api/api_keys.go | Replaces `uuid.Nil` with custom `stringUUIDSchema` type that implements JSONSchema interface for proper UUID swagger documentation |
| go.mod | Bumps `go.lumeweb.com/portal-router` from v0.6.10 to v0.6.11, likely supporting the stringUUIDSchema pattern |
| go.sum | Updates checksums for portal-router v0.6.11 dependency |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Router
    participant Swagger
    participant DeleteHandler
    
    Note over Router,Swagger: Route Definition Phase
    Router->>Swagger: WithPathParam("keyID", ..., stringUUIDSchema(""))
    stringUUIDSchema("")->>Swagger: JSONSchema() returns {type: "string", format: "uuid"}
    Swagger->>Swagger: Generate OpenAPI spec with UUID format
    
    Note over Client,DeleteHandler: Runtime Phase
    Client->>Router: DELETE /api/account/keys/{uuid}
    Router->>DeleteHandler: Route to deleteAPIKey handler
    DeleteHandler->>DeleteHandler: uuid.Parse(c.Param("keyID"))
    DeleteHandler->>DeleteHandler: Delete API key if valid
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->