### PR TITLE
ci(workflows): use centralized release workflow from LumeWeb/workflows

### DIFF
--- a/.git-town.toml
+++ b/.git-town.toml
@@ -2,3 +2,19 @@
 
 [branches]
 main = "develop"
+
+[create]
+share-new-branches = "no"
+
+[hosting]
+forge-type = "github"
+github-connector = "gh"
+
+[ship]
+delete-tracking-branch = true
+
+[sync]
+feature-strategy = "rebase"
+perennial-strategy = "rebase"
+push-hook = true
+upstream = true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,28 +3,8 @@ name: Release
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 jobs:
   release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.PAT }}
-
-      - name: Install Knope
-        uses: knope-dev/action@v2.1.0
-        with:
-          version: 0.21.7
-
-      - name: Setup Git
-        uses: LumeWeb/workflows/.github/actions/setup-git@develop
-
-      - name: Create Release
-        run: knope release --verbose
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
+    uses: LumeWeb/workflows/.github/workflows/release.yml@develop
+    secrets:
+      PAT: ${{ secrets.PAT }}


### PR DESCRIPTION
- Replace inline release workflow with LumeWeb/workflows/.github/workflows/release.yml@develop
- Remove redundant checkout, Knope installation, and Git setup steps
- Remove explicit permissions (inherited from centralized workflow)
- Add Git Town configuration for branch management strategy

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

Migrates the release workflow to use the centralized `LumeWeb/workflows/.github/workflows/release.yml@develop` template, removing 20+ lines of inline workflow steps. Adds comprehensive Git Town configuration for branch management strategies including rebase-based sync and GitHub integration.

### Confidence Score: 3/5

- Generally safe workflow consolidation, but missing permissions inheritance may prevent release operations
- The workflow migration follows the established pattern in this repository (build.yml and update-ui.yml already use centralized workflows). However, the removal of `permissions: contents: write` without explicit inheritance at the job level could cause the release workflow to fail when attempting to create releases, push tags, or commit version changes. The Git Town configuration additions are standard and pose no risk.
- .github/workflows/release.yml needs verification that permissions are properly inherited or defined in the centralized workflow

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/release.yml | 4/5 | Simplifies workflow by delegating to centralized LumeWeb/workflows release template; properly passes PAT secret |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Caller as release.yml<br/>(Caller Workflow)
    participant Centralized as LumeWeb/workflows<br/>release.yml
    participant GitHub as GitHub API
    participant Knope

    User->>Caller: Trigger workflow_dispatch
    Caller->>Centralized: Call reusable workflow<br/>pass PAT secret
    Centralized->>Centralized: Checkout repository
    Centralized->>Centralized: Install Knope
    Centralized->>Centralized: Setup Git config
    Centralized->>Knope: Run knope release
    Knope->>GitHub: Create release & tags
    Knope->>GitHub: Push version commits
    GitHub-->>User: Release created
```

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/release.yml | 4/5 | Simplifies workflow by delegating to centralized LumeWeb/workflows release template; properly passes PAT secret |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Caller as release.yml<br/>(Caller Workflow)
    participant Centralized as LumeWeb/workflows<br/>release.yml
    participant GitHub as GitHub API
    participant Knope

    User->>Caller: Trigger workflow_dispatch
    Caller->>Centralized: Call reusable workflow<br/>pass PAT secret
    Centralized->>Centralized: Checkout repository
    Centralized->>Centralized: Install Knope
    Centralized->>Centralized: Setup Git config
    Centralized->>Knope: Run knope release
    Knope->>GitHub: Create release & tags
    Knope->>GitHub: Push version commits
    GitHub-->>User: Release created
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->