### PR TITLE
ci: add secrets inherit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,3 +11,4 @@ jobs:
     uses: LumeWeb/workflows/.github/workflows/build-plugin.yml@develop
     with:
       additional_dependencies: go.lumeweb.com/portal-plugin-core
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,5 +6,4 @@ on:
 jobs:
   release:
     uses: LumeWeb/workflows/.github/workflows/release.yml@develop
-    secrets:
-      PAT: ${{ secrets.PAT }}
+    secrets: inherit

--- a/.github/workflows/update-ui.yml
+++ b/.github/workflows/update-ui.yml
@@ -15,5 +15,4 @@ jobs:
       commit_hash: ${{ github.event.client_payload.commit_hash }}
       app_name: ${{ github.event.client_payload.app_name }}
       repository: ${{ github.event.client_payload.repository }}
-    secrets:
-      PAT: ${{ secrets.PAT }}
+    secrets: inherit


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the GitHub Actions workflow configurations to automatically pass all repository secrets to reusable workflows.

Specifically, the changes apply to the `build.yml`, `release.yml`, and `update-ui.yml` files. By replacing explicit secret definitions (or the lack thereof) with the `secrets: inherit` directive, the workflows now forward all available secrets to the downstream reusable workflows. This simplifies secret management and ensures that called workflows have access to necessary credentials without requiring individual secret mapping.
<!-- kody-pr-summary:end -->