### PR TITLE
fix(auth): remove unused auth import

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -26,7 +26,6 @@ import (
 	"github.com/samber/lo"
 	swagger "go.lumeweb.com/gswagger"
 	"go.lumeweb.com/httputil"
-	"go.lumeweb.com/portal-middleware/auth"
 	"go.lumeweb.com/portal-middleware/auth/adapter"
 	"go.lumeweb.com/portal-middleware/auth/jwt"
 	mcontext "go.lumeweb.com/portal-middleware/context"


### PR DESCRIPTION
Remove unused "go.lumeweb.com/portal-middleware/auth" import
that was causing build failure: imported and not used error.
