### PR TITLE
fix(auth): add missing auth import

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -26,6 +26,7 @@ import (
 	"github.com/samber/lo"
 	swagger "go.lumeweb.com/gswagger"
 	"go.lumeweb.com/httputil"
+	"go.lumeweb.com/portal-middleware/auth"
 	"go.lumeweb.com/portal-middleware/auth/adapter"
 	"go.lumeweb.com/portal-middleware/auth/jwt"
 	mcontext "go.lumeweb.com/portal-middleware/context"


### PR DESCRIPTION
The auth import is actually used by auth.ParseAuthTokenHeader()
which was added in the API key authentication improvements.
This fixes the 'undefined: auth' build error.
