### PR TITLE
fix(api): remove default 200 response from OTP validate endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	go.lumeweb.com/httputil v0.5.4
 	go.lumeweb.com/portal v0.4.2-0.20260210183348-979be8735f77
 	go.lumeweb.com/portal-middleware v0.3.4
-	go.lumeweb.com/portal-router v0.6.11
+	go.lumeweb.com/portal-router v0.6.12
 	go.lumeweb.com/queryutil v0.3.15
 	go.lumeweb.com/web/go/portal-dashboard v0.0.0-20260123053442-479cd558a2fc
 	go.lumeweb.com/web/go/portal-plugin-dashboard v0.0.0-20260123053442-479cd558a2fc

--- a/go.sum
+++ b/go.sum
@@ -811,6 +811,8 @@ go.lumeweb.com/portal-middleware v0.3.4 h1:A9/Ipo3giX449CCgbKGco97IqDxFG7Z1ppmM1
 go.lumeweb.com/portal-middleware v0.3.4/go.mod h1:3dHvOYXApc1b673I1UAoYBpyXg2c7ku4HqxXvef8dj8=
 go.lumeweb.com/portal-router v0.6.11 h1:0PTej57mtNcRpKZNukD0j0ZYp5ntbR7fl5g6DO+0mvk=
 go.lumeweb.com/portal-router v0.6.11/go.mod h1:4tb+XYa0GYiFVraMoossGgMBTN9z4U54v8SL+EOBvbs=
+go.lumeweb.com/portal-router v0.6.12 h1:IbQsz9AgRST/co2hsYmjqewUerXgunONrIqbTz/cfTM=
+go.lumeweb.com/portal-router v0.6.12/go.mod h1:4tb+XYa0GYiFVraMoossGgMBTN9z4U54v8SL+EOBvbs=
 go.lumeweb.com/queryutil v0.3.15 h1:R2l6GAAne8rCgh1rGy5HQ54zvs8JJw3gRLjhmkd8SHk=
 go.lumeweb.com/queryutil v0.3.15/go.mod h1:nLkIuXzugX8Ln24wsAbfTafvNmaTHLJhIUKWC1693G4=
 go.lumeweb.com/web/go/portal-dashboard v0.0.0-20260123053442-479cd558a2fc h1:75sjqoO6sy15ONcUO9P+gRsu3CyYA+fbfoER3YLPBTk=

--- a/internal/api/api_otp.go
+++ b/internal/api/api_otp.go
@@ -30,6 +30,7 @@ func (a *API) buildOTPRoutes(authMw echo.MiddlewareFunc, loginAuthMw2fa echo.Mid
 		),
 		router.NewRoute(http.MethodPost, "/api/auth/otp/validate", a.otpValidate,
 			router.WithSwaggerOptions(
+				router.WithoutDefaultSuccessResponse(),
 				router.WithSummary("Validate OTP code"),
 				router.WithDescription("Validates an OTP code to complete 2FA login."),
 				router.WithRequestBody(dto.OTPValidateRequest{}, "OTP code", true),


### PR DESCRIPTION
The OTP validate endpoint returns a 302 redirect on success, so it should not
include the default 200 OK response in its Swagger documentation. Added
WithoutDefaultSuccessResponse() option to properly document the 302 redirect.

Updated portal-router to v0.6.12 which introduces the WithoutDefaultSuccessResponse()
option for endpoints that return non-200 success codes.


---

<!-- kody-pr-summary:start -->
 Removes the default 200 success response from the Swagger documentation for the OTP validation endpoint (`/api/auth/otp/validate`). 

This fix corrects the API documentation to accurately reflect that the endpoint returns a 302 redirect upon successful validation rather than a standard 200 JSON response, ensuring the Swagger spec aligns with the actual authentication flow behavior.
<!-- kody-pr-summary:end -->