### PR TITLE
chore: fix typo

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 
 	z "github.com/Oudwins/zog"
-	"github.com/Oudwins/zog/pkg/internals"
+	"github.com/Oudwins/zog/pkgs/internals"
 	"go.lumeweb.com/portal/config"
 )
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Fix import path typo for the `zog` dependency, changing `pkg/internals` to `pkgs/internals` to match the upstream package's directory structure.
<!-- kody-pr-summary:end -->