### PR TITLE
fix: map operation filter/sort fields to DB columns before querying

### DIFF
--- a/internal/api/api_operation.go
+++ b/internal/api/api_operation.go
@@ -196,9 +196,11 @@ func (a *API) listOperations(c echo.Context) error {
 		c.Request(),
 		"operations",
 		func(filters []queryutil.CrudFilter, sorts []queryutil.Sort, pagination queryutil.Pagination) ([]*dto.OperationListItem, int64, error) {
+			dbFilters := mapOperationFilters(filters)
+			dbSorts := mapOperationSorts(sorts)
+
 			reqCtx := ctx.Request().Context()
-			// Use ListWorkflowInstances instead of GetRequests
-			instances, total, err := a.workflowSvc.ListWorkflowInstances(reqCtx, userID, filters, sorts, pagination)
+			instances, total, err := a.workflowSvc.ListWorkflowInstances(reqCtx, userID, dbFilters, dbSorts, pagination)
 			if err != nil {
 				return nil, 0, err
 			}

--- a/internal/api/api_operation.go
+++ b/internal/api/api_operation.go
@@ -196,7 +196,10 @@ func (a *API) listOperations(c echo.Context) error {
 		c.Request(),
 		"operations",
 		func(filters []queryutil.CrudFilter, sorts []queryutil.Sort, pagination queryutil.Pagination) ([]*dto.OperationListItem, int64, error) {
-			dbFilters := mapOperationFilters(filters)
+			dbFilters, err := mapOperationFilters(filters)
+			if err != nil {
+				return nil, 0, err
+			}
 			dbSorts := mapOperationSorts(sorts)
 
 			reqCtx := ctx.Request().Context()

--- a/internal/api/dto/operation.go
+++ b/internal/api/dto/operation.go
@@ -21,10 +21,14 @@ type OperationRequest struct {
 }
 
 type OperationFilterRequest struct {
-	ID              uint64  `json:"id" filter:"true"`
-	Operation       string  `json:"operation" filter:"true"`
-	ProgressPercent float64 `json:"progress_percent" filter:"true"`
-	CID             string  `json:"cid" filter:"true"`
+	ID            uint64                   `json:"id" filter:"true"`
+	Operation     string                   `json:"operation" filter:"true"`
+	Protocol      string                   `json:"protocol" filter:"true"`
+	Status        models.RequestStatusType `json:"status" filter:"true"`
+	StatusMessage string                   `json:"status_message" filter:"true"`
+	CID           string                   `json:"cid" filter:"true"`
+	StartedAt     time.Time                `json:"started_at" filter:"true"`
+	UpdatedAt     time.Time                `json:"updated_at" filter:"true"`
 }
 
 func (r *OperationRequest) Schema() *z.StructSchema {
@@ -46,14 +50,14 @@ type OperationListItem struct {
 	Status                models.RequestStatusType `json:"status" filter:"true" sort:"true"`
 	StatusDisplayName     string                   `json:"status_display_name"`
 	StatusMessage         string                   `json:"status_message" filter:"true" sort:"true"`
-	ProgressPercent       float64                  `json:"progress_percent" filter:"true" sort:"true"`
+	ProgressPercent       float64                  `json:"progress_percent"`
 	StartedAt             time.Time                `json:"started_at" filter:"true" sort:"true"`
 	UpdatedAt             time.Time                `json:"updated_at" filter:"true" sort:"true"`
-	EstimatedCompletionAt *time.Time               `json:"estimated_completion_at,omitempty" filter:"true" sort:"true"`
-	CID                   *string                  `json:"cid,omitempty" filter:"true" sort:"true"`
-	TotalSteps            *int64                   `json:"total_steps,omitempty" filter:"true" sort:"true"`
-	CurrentStep           *int64                   `json:"current_step,omitempty" filter:"true" sort:"true"`
-	Error                 *string                  `json:"error,omitempty" filter:"true" sort:"true"`
+	EstimatedCompletionAt *time.Time               `json:"estimated_completion_at,omitempty"`
+	CID                   *string                  `json:"cid,omitempty" filter:"true"`
+	TotalSteps            *int64                   `json:"total_steps,omitempty"`
+	CurrentStep           *int64                   `json:"current_step,omitempty"`
+	Error                 *string                  `json:"error,omitempty"`
 }
 
 func (r *OperationListItem) FromModel(model *OperationListItem) error {

--- a/internal/api/operation_filter_mapping.go
+++ b/internal/api/operation_filter_mapping.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"github.com/ipfs/go-cid"
+	queryutilFilter "go.lumeweb.com/queryutil/filter"
+)
+
+var operationFieldMappings = map[string]string{
+	"id":             "id",
+	"operation":      "operation",
+	"protocol":       "protocol",
+	"status":         "status",
+	"status_message": "status_message",
+	"started_at":     "created_at",
+	"updated_at":     "updated_at",
+	"cid":            "hash",
+}
+
+func mapOperationFilters(filters []queryutilFilter.CrudFilter) []queryutilFilter.CrudFilter {
+	result := make([]queryutilFilter.CrudFilter, 0, len(filters))
+	for _, f := range filters {
+		result = append(result, mapOperationFilter(f))
+	}
+	return result
+}
+
+func mapOperationFilter(f queryutilFilter.CrudFilter) queryutilFilter.CrudFilter {
+	switch v := f.(type) {
+	case *queryutilFilter.LogicalFilter:
+		field := v.Field()
+		dbField, mapped := operationFieldMappings[field]
+		if !mapped {
+			return f
+		}
+
+		value := v.GetValue()
+		if field == "cid" {
+			decoded, err := decodeCIDToMultihash(value)
+			if err != nil || decoded == nil {
+				return f
+			}
+			return queryutilFilter.NewLogicalFilter(dbField, v.Operator(), decoded)
+		}
+
+		return queryutilFilter.NewLogicalFilter(dbField, v.Operator(), value)
+	case *queryutilFilter.ConditionalFilter:
+		mappedFilters := make([]queryutilFilter.CrudFilter, 0, len(v.Filters))
+		for _, nested := range v.Filters {
+			mappedFilters = append(mappedFilters, mapOperationFilter(nested))
+		}
+		return queryutilFilter.NewConditionalFilter(queryutilFilter.LogicalOperator(v.GetOperator()), mappedFilters)
+	default:
+		return f
+	}
+}
+
+func mapOperationSorts(sorts []queryutilFilter.Sort) []queryutilFilter.Sort {
+	result := make([]queryutilFilter.Sort, 0, len(sorts))
+	for _, s := range sorts {
+		dbField, mapped := operationFieldMappings[s.Field]
+		if !mapped {
+			result = append(result, s)
+			continue
+		}
+		result = append(result, queryutilFilter.Sort{
+			Field: dbField,
+			Order: s.Order,
+		})
+	}
+	return result
+}
+
+func decodeCIDToMultihash(value any) ([]byte, error) {
+	cidStr, ok := value.(string)
+	if !ok {
+		return nil, nil
+	}
+
+	decoded, err := cid.Decode(cidStr)
+	if err != nil {
+		return nil, err
+	}
+
+	return decoded.Hash(), nil
+}

--- a/internal/api/operation_filter_mapping.go
+++ b/internal/api/operation_filter_mapping.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/ipfs/go-cid"
 	queryutilFilter "go.lumeweb.com/queryutil/filter"
 )
@@ -16,41 +18,52 @@ var operationFieldMappings = map[string]string{
 	"cid":            "hash",
 }
 
-func mapOperationFilters(filters []queryutilFilter.CrudFilter) []queryutilFilter.CrudFilter {
+func mapOperationFilters(filters []queryutilFilter.CrudFilter) ([]queryutilFilter.CrudFilter, error) {
 	result := make([]queryutilFilter.CrudFilter, 0, len(filters))
 	for _, f := range filters {
-		result = append(result, mapOperationFilter(f))
+		mapped, err := mapOperationFilter(f)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, mapped)
 	}
-	return result
+	return result, nil
 }
 
-func mapOperationFilter(f queryutilFilter.CrudFilter) queryutilFilter.CrudFilter {
+func mapOperationFilter(f queryutilFilter.CrudFilter) (queryutilFilter.CrudFilter, error) {
 	switch v := f.(type) {
 	case *queryutilFilter.LogicalFilter:
 		field := v.Field()
 		dbField, mapped := operationFieldMappings[field]
 		if !mapped {
-			return f
+			return f, nil
 		}
 
 		value := v.GetValue()
 		if field == "cid" {
 			decoded, err := decodeCIDToMultihash(value)
-			if err != nil || decoded == nil {
-				return f
+			if err != nil {
+				return nil, fmt.Errorf("invalid cid filter value: %w", err)
 			}
-			return queryutilFilter.NewLogicalFilter(dbField, v.Operator(), decoded)
+			if decoded == nil {
+				return nil, fmt.Errorf("cid filter requires a string value, got %T", value)
+			}
+			return queryutilFilter.NewLogicalFilter(dbField, v.Operator(), decoded), nil
 		}
 
-		return queryutilFilter.NewLogicalFilter(dbField, v.Operator(), value)
+		return queryutilFilter.NewLogicalFilter(dbField, v.Operator(), value), nil
 	case *queryutilFilter.ConditionalFilter:
 		mappedFilters := make([]queryutilFilter.CrudFilter, 0, len(v.Filters))
 		for _, nested := range v.Filters {
-			mappedFilters = append(mappedFilters, mapOperationFilter(nested))
+			mapped, err := mapOperationFilter(nested)
+			if err != nil {
+				return nil, err
+			}
+			mappedFilters = append(mappedFilters, mapped)
 		}
-		return queryutilFilter.NewConditionalFilter(queryutilFilter.LogicalOperator(v.GetOperator()), mappedFilters)
+		return queryutilFilter.NewConditionalFilter(queryutilFilter.LogicalOperator(v.GetOperator()), mappedFilters), nil
 	default:
-		return f
+		return f, nil
 	}
 }
 


### PR DESCRIPTION
Filters and sorts from the operation list endpoint used DTO field names
(started_at, cid) directly against the Request model, causing silent
failures or wrong column queries. Add explicit field mapping so started_at
maps to created_at and cid decodes to multihash bytes for the hash column.
Also remove filter/sort tags from computed-only fields (progress_percent,
total_steps, current_step, error, estimated_completion_at) that have no DB
backing, and add missing filterable fields (protocol, status,
status_message) to OperationFilterRequest.

---

<!-- kody-pr-summary:start -->
Fix operation filter and sort field mapping to database columns

This PR fixes the operation listing endpoint by mapping API-level filter/sort field names to their corresponding database column names before querying. Without this mapping, filters and sorts on fields like `started_at` and `cid` would fail because the database uses different column names (`created_at` and `hash` respectively).

Key changes:
- **Added field mapping layer** (`operation_filter_mapping.go`): Maps API field names to DB columns, notably `started_at` → `created_at` and `cid` → `hash`, with special CID-to-multihash decoding for CID filters.
- **Updated filter/sort flow** (`api_operation.go`): Filters and sorts are now mapped through `mapOperationFilters()` and `mapOperationSorts()` before being passed to the database query.
- **Refined filterable/sortable fields** (`dto/operation.go`): Added `Protocol`, `Status`, `StatusMessage`, `StartedAt`, and `UpdatedAt` as filterable fields; removed filter/sort tags from `ProgressPercent`, `EstimatedCompletionAt`, `TotalSteps`, `CurrentStep`, and `Error` as these don't have direct DB column mappings.
<!-- kody-pr-summary:end -->