### PR TITLE
feat: add logo_url config to dashboard plugin

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	_ "embed"
+	"encoding/json"
 	"errors"
 	"fmt"
 	_ "image/gif"
@@ -50,6 +51,10 @@ const (
 	AuthCompletePath = "/api/auth/complete" // Path for authentication complete endpoint
 	RememberMeCookie = "remember_me"        // Cookie name for remember me flag
 )
+
+type brandConfig struct {
+	LogoURL string `json:"logoUrl"`
+}
 
 var _ core.API = (*API)(nil)
 
@@ -542,7 +547,12 @@ func (a *API) Configure(gRouter router.Router, accessSvc core.AccessService) err
 		router.MustDefaultPublicFilesSetup(gRouter, pluginCfg.AppFolder)
 	} else {
 		// Using the new WebAppConfig helper with embedded assets
-		router.MustDefaultStaticSetup(gRouter, router.NewAppFilesystem(portal_dashboard.GetFS(), router.AppFilesystemConfig{Domain: a.Config().Config().Core.Domain}))
+		fsConfig := router.AppFilesystemConfig{Domain: a.Config().Config().Core.Domain}
+		if pluginCfg.LogoURL != "" {
+			brand, _ := json.Marshal(brandConfig{LogoURL: pluginCfg.LogoURL})
+			fsConfig.BrandJSON = string(brand)
+		}
+		router.MustDefaultStaticSetup(gRouter, router.NewAppFilesystem(portal_dashboard.GetFS(), fsConfig))
 	}
 
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ type APIConfig struct {
 	SocialLogin SocialLogin `config:"social_login"`
 	AppFolder   string      `config:"app_folder"`
 	Themes      Themes      `config:"themes"`
+	LogoURL     string      `config:"logo_url"`
 }
 
 func (a APIConfig) Schema() z.ZogSchema {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Add `logo_url` configuration option to the dashboard plugin, allowing a custom logo URL to be specified. When configured, the logo URL is passed as brand JSON (`brandUrl`) to the app filesystem setup, enabling the dashboard to display a custom logo instead of the default.
<!-- kody-pr-summary:end -->