### PR TITLE
refactor: group branding props into Branding struct

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -52,10 +52,6 @@ const (
 	RememberMeCookie = "remember_me"        // Cookie name for remember me flag
 )
 
-type brandConfig struct {
-	LogoURL string `json:"logoUrl"`
-}
-
 var _ core.API = (*API)(nil)
 
 type API struct {
@@ -548,8 +544,8 @@ func (a *API) Configure(gRouter router.Router, accessSvc core.AccessService) err
 	} else {
 		// Using the new WebAppConfig helper with embedded assets
 		fsConfig := router.AppFilesystemConfig{Domain: a.Config().Config().Core.Domain}
-		if pluginCfg.LogoURL != "" {
-			brand, _ := json.Marshal(brandConfig{LogoURL: pluginCfg.LogoURL})
+		if pluginCfg.Branding.LogoURL != "" || pluginCfg.Branding.FaviconURL != "" {
+			brand, _ := json.Marshal(pluginCfg.Branding)
 			fsConfig.BrandJSON = string(brand)
 		}
 		router.MustDefaultStaticSetup(gRouter, router.NewAppFilesystem(portal_dashboard.GetFS(), fsConfig))

--- a/internal/config/branding.go
+++ b/internal/config/branding.go
@@ -1,0 +1,20 @@
+package config
+
+import (
+	z "github.com/Oudwins/zog"
+	"go.lumeweb.com/portal/config"
+)
+
+var _ config.ConfigSchemaProvider = (*Branding)(nil)
+
+type Branding struct {
+	LogoURL    string `config:"logo_url" json:"logoUrl"`
+	FaviconURL string `config:"favicon_url" json:"faviconUrl"`
+}
+
+func (b Branding) Schema() z.ZogSchema {
+	return z.Struct(z.Shape{
+		"LogoURL":    z.String(),
+		"FaviconURL": z.String(),
+	})
+}

--- a/internal/config/branding.go
+++ b/internal/config/branding.go
@@ -8,8 +8,8 @@ import (
 var _ config.ConfigSchemaProvider = (*Branding)(nil)
 
 type Branding struct {
-	LogoURL    string `config:"logo_url" json:"logoUrl"`
-	FaviconURL string `config:"favicon_url" json:"faviconUrl"`
+	LogoURL    string `config:"logo_url" json:"logoUrl,omitempty"`
+	FaviconURL string `config:"favicon_url" json:"faviconUrl,omitempty"`
 }
 
 func (b Branding) Schema() z.ZogSchema {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,14 +17,14 @@ type APIConfig struct {
 	SocialLogin SocialLogin `config:"social_login"`
 	AppFolder   string      `config:"app_folder"`
 	Themes      Themes      `config:"themes"`
-	LogoURL     string      `config:"logo_url"`
+	Branding    Branding    `config:"branding"`
 }
 
 func (a APIConfig) Schema() z.ZogSchema {
 	return z.Struct(z.Shape{
-		"Subdomain": z.String().Required(),
-		"AppFolder": z.String(),
-		"Themes": z.Slice(z.Struct(z.Shape{})).TestFunc(func(val any, ctx internals.Ctx) bool {
+		"Subdomain":   z.String().Required(),
+		"AppFolder":   z.String(),
+		"Themes":      z.Slice(z.Struct(z.Shape{})).TestFunc(func(val any, ctx internals.Ctx) bool {
 			def := false
 			for _, theme := range reflect.ValueOf(val).Elem().Interface().(Themes) {
 				if theme.Default {
@@ -36,6 +36,10 @@ func (a APIConfig) Schema() z.ZogSchema {
 				}
 			}
 			return true
+		}),
+		"Branding": z.Struct(z.Shape{
+			"LogoURL":    z.String(),
+			"FaviconURL": z.String(),
 		}),
 	})
 }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Pull Request Description

This PR refactors the dashboard plugin's branding configuration by grouping branding-related properties into a dedicated `Branding` struct.

### Changes

- **Created `Branding` struct** (`internal/config/branding.go`): A new configuration struct that consolidates branding properties, currently including `LogoURL` and a newly added `FaviconURL` field. The struct implements the `ConfigSchemaProvider` interface for validation.

- **Updated `APIConfig`** (`internal/config/config.go`): Replaced the flat `LogoURL` field with a nested `Branding` field, and updated the corresponding validation schema to include both `LogoURL` and `FaviconURL`.

- **Updated API initialization** (`internal/api/api.go`): Removed the local `brandConfig` struct and now directly marshals the `Branding` struct. The branding JSON is now emitted when either `LogoURL` or `FaviconURL` is configured.

### Functional Impact

- The configuration structure changes from a top-level `logo_url` key to a nested `branding` section containing `logo_url` and `favicon_url`.
- Adds support for configuring a custom favicon URL for the dashboard, alongside the existing logo URL customization.
<!-- kody-pr-summary:end -->