### PR TITLE
feat: add enum constraints to Status filter params in OpenAPI spec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,8 +24,8 @@ require (
 	go.lumeweb.com/httputil v0.5.4
 	go.lumeweb.com/portal v0.4.2-0.20260312035701-66ae43ad8cad
 	go.lumeweb.com/portal-middleware v0.3.5
-	go.lumeweb.com/portal-router v0.7.0
-	go.lumeweb.com/queryutil v0.3.15
+	go.lumeweb.com/portal-router v0.7.2
+	go.lumeweb.com/queryutil v0.3.17
 	go.lumeweb.com/web/go/portal-dashboard v0.0.0-20260630050642-1465adcffeab
 	go.lumeweb.com/web/go/portal-plugin-dashboard v0.0.0-20260630050642-1465adcffeab
 	go.uber.org/zap v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -824,10 +824,10 @@ go.lumeweb.com/portal v0.4.2-0.20260312035701-66ae43ad8cad h1:OqUAyI6QOkXcrbXHDw
 go.lumeweb.com/portal v0.4.2-0.20260312035701-66ae43ad8cad/go.mod h1:3LG8ylUL39VYH0G8AVikCpqjQ/tk4lnkSVFlsosixwg=
 go.lumeweb.com/portal-middleware v0.3.5 h1:QwW1cvw4VbSK3rfzW7TwbfezueUXNX80Y/WS97qfoyU=
 go.lumeweb.com/portal-middleware v0.3.5/go.mod h1:Yn9ZsFy5n3x2jUJ085M9B/aoZ+ANQV5QD/MAE0BpJXo=
-go.lumeweb.com/portal-router v0.7.0 h1:sFPsWyo7gB3Eq5r4pmb1TVWr984721Q0++Vhi2Tnq7s=
-go.lumeweb.com/portal-router v0.7.0/go.mod h1:hl51sHDKcgw8yxJ6RraYBOI1Vnufq33FhKwfKiqCkVg=
-go.lumeweb.com/queryutil v0.3.15 h1:R2l6GAAne8rCgh1rGy5HQ54zvs8JJw3gRLjhmkd8SHk=
-go.lumeweb.com/queryutil v0.3.15/go.mod h1:nLkIuXzugX8Ln24wsAbfTafvNmaTHLJhIUKWC1693G4=
+go.lumeweb.com/portal-router v0.7.2 h1:x6P7hkYqGx20aZ8IU0eC2sXpVHsorfHvO4js82JUNQk=
+go.lumeweb.com/portal-router v0.7.2/go.mod h1:hl51sHDKcgw8yxJ6RraYBOI1Vnufq33FhKwfKiqCkVg=
+go.lumeweb.com/queryutil v0.3.17 h1:rbMj1ZpG1KL1UUvMYS9+JYdjOcUW6YAfXjy0J2XPWYI=
+go.lumeweb.com/queryutil v0.3.17/go.mod h1:6bcNItUrPwjGAz9pBFPxO509apXcWU8VD1lc+vur/IA=
 go.lumeweb.com/web/go/portal-dashboard v0.0.0-20260630050642-1465adcffeab h1:yNwszY68sEF0chpzRyga1vtblPuJ5VEYZKD1jUi0sJY=
 go.lumeweb.com/web/go/portal-dashboard v0.0.0-20260630050642-1465adcffeab/go.mod h1:jThuERESHfYaopsar2WrVSi2Oyi6Xu9tySu5IAu7xJ4=
 go.lumeweb.com/web/go/portal-plugin-dashboard v0.0.0-20260630050642-1465adcffeab h1:AQVzMUOktiaVSvgra5ke3AlRu20KNO8SHRCPWJLb/D8=

--- a/internal/api/dto/operation.go
+++ b/internal/api/dto/operation.go
@@ -24,7 +24,7 @@ type OperationFilterRequest struct {
 	ID            uint64                   `json:"id" filter:"true"`
 	Operation     string                   `json:"operation" filter:"true"`
 	Protocol      string                   `json:"protocol" filter:"true"`
-	Status        models.RequestStatusType `json:"status" filter:"true"`
+	Status        models.RequestStatusType `json:"status" filter:"true" jsonschema:"enum=pending,enum=processing,enum=completed,enum=failed,enum=duplicate"`
 	StatusMessage string                   `json:"status_message" filter:"true"`
 	CID           string                   `json:"cid" filter:"true"`
 	StartedAt     time.Time                `json:"started_at" filter:"true"`
@@ -47,7 +47,7 @@ type OperationListItem struct {
 	OperationDisplayName  string                   `json:"operation_display_name"`
 	Protocol              string                   `json:"protocol" filter:"true" sort:"true"`
 	ProtocolDisplayName   string                   `json:"protocol_display_name"`
-	Status                models.RequestStatusType `json:"status" filter:"true" sort:"true"`
+	Status                models.RequestStatusType `json:"status" filter:"true" sort:"true" jsonschema:"enum=pending,enum=processing,enum=completed,enum=failed,enum=duplicate"`
 	StatusDisplayName     string                   `json:"status_display_name"`
 	StatusMessage         string                   `json:"status_message" filter:"true" sort:"true"`
 	ProgressPercent       float64                  `json:"progress_percent"`


### PR DESCRIPTION
## Summary
- Adds jsonschema enum tags to OperationFilterRequest.Status and OperationListItem.Status
- Bumps portal-router to v0.7.2 and queryutil to v0.3.17 for FieldEnums() support
- The OpenAPI spec now declares valid status values: pending, processing, completed, failed, duplicate

---

<!-- kody-pr-summary:start -->
This pull request adds `enum` constraints to the `Status` field in the OpenAPI specification for operation-related DTOs. Specifically, it defines the allowed status values (`pending`, `processing`, `completed`, `failed`, and `duplicate`) for the `Status` field in both the `OperationFilterRequest` and `OperationListItem` structs. This improves API documentation by explicitly listing the valid status values that can be used for filtering and that will be present in operation list responses.
<!-- kody-pr-summary:end -->