### PR TITLE
fix(api_key): wire name search so api_keys_list 'q' is not a no-op

### DIFF
--- a/internal/service/api_key/api_key.go
+++ b/internal/service/api_key/api_key.go
@@ -14,6 +14,7 @@ import (
 	"go.lumeweb.com/portal/db"
 	"go.lumeweb.com/portal/db/types"
 	"go.lumeweb.com/queryutil"
+	"go.lumeweb.com/queryutil/filter"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
@@ -82,8 +83,11 @@ func (s *APIKeyServiceDefault) GetAPIKeys(ctx context.Context, userID uint, filt
 
 	query := s.DB().Model(&pluginDb.APIKey{}).Where(&pluginDb.APIKey{UserID: userID})
 
-	// Apply filters, sorts and pagination using queryutil helpers
-	query = queryutil.ApplyFilters(query, filters, nil)
+	// Apply filters, sorts and pagination using queryutil helpers. Wire up the
+	// global-search config so a 'q' search (api_keys_list's search arg) filters
+	// the name column; without it the builder silently drops 'q' as a no-op.
+	searchConfig := &filter.GlobalSearchConfig{SearchableColumns: []string{"name"}}
+	query = queryutil.ApplyFilters(query, filters, searchConfig)
 	query = queryutil.ApplySort(query, sorts)
 
 	if err := query.Count(&total).Error; err != nil {

--- a/internal/service/api_key/api_key_test.go
+++ b/internal/service/api_key/api_key_test.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	pluginDb "go.lumeweb.com/portal-plugin-dashboard/internal/db/models"
-	pluginDbMigrations "go.lumeweb.com/portal-plugin-dashboard/internal/db/migrations"
 	pluginCore "go.lumeweb.com/portal-plugin-dashboard/core"
+	pluginDbMigrations "go.lumeweb.com/portal-plugin-dashboard/internal/db/migrations"
+	pluginDb "go.lumeweb.com/portal-plugin-dashboard/internal/db/models"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
 	"go.lumeweb.com/queryutil"
@@ -195,6 +195,32 @@ func TestAPIKeyService_GetAPIKeys_FilterByName(t *testing.T) {
 		require.NoError(tb, err)
 		err = apiKeyService.DeleteAPIKey(context.Background(), userID, key2.UUID.ToUUID())
 		require.NoError(tb, err)
+	})
+}
+
+func TestAPIKeyService_GetAPIKeys_GlobalSearch(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		apiKeyService := core.GetService[pluginCore.APIKeyService](ctx, pluginCore.API_KEY_SERVICE)
+		require.NotNil(tb, apiKeyService)
+
+		userID := uint(1)
+		_, err := apiKeyService.CreateAPIKey(context.Background(), userID, "Production Key")
+		require.NoError(tb, err)
+		_, err = apiKeyService.CreateAPIKey(context.Background(), userID, "Staging Key")
+		require.NoError(tb, err)
+
+		// api_keys_list's search arg arrives as a global 'q' filter. It must
+		// filter the name column rather than be silently dropped (regression:
+		// previously a nil search config made 'q' a no-op that returned every key).
+		filters := []queryutil.CrudFilter{queryutil.Equal("q", "production")}
+		sorts := []queryutil.Sort{}
+		pagination := queryutil.DefaultPagination
+
+		keys, total, err := apiKeyService.GetAPIKeys(context.Background(), userID, filters, sorts, pagination)
+		require.NoError(tb, err)
+		assert.Equal(tb, int64(1), total, "q search must match only 'Production Key'")
+		assert.Len(tb, keys, 1)
+		assert.Equal(tb, "Production Key", keys[0].Name)
 	})
 }
 


### PR DESCRIPTION
## Problem

`api_keys_list`'s `name`/`search` filter is a no-op. Passing a matching name, a non-matching name, or no filter all return the identical full key list. Silent at scale: an agent trusting the filter acts on the wrong key set.

## Root cause

`GetAPIKeys` passed `nil` as the search config to `queryutil.ApplyFilters`. The GORM builder's `q` (global search) handler drops the filter entirely when searchable columns are empty (queryutil/gorm_builder), so the `q` argument sent by the SDK's search was never applied.

## Fix

Wire `filter.GlobalSearchConfig{SearchableColumns: []string{"name"}}` so the `q` argument filters on the `name` column.

## Verification

`TestAPIKeyService_GetAPIKeys_GlobalSearch` verifies a `q` search returns only the matching key. It is mutation-sensitive: reverting the search config to `nil` makes the test return all keys instead of the single name match. Full `internal/service/api_key` suite passes.

---

<!-- kody-pr-summary:start -->
This pull request fixes a bug where the global search functionality in the API keys list was not working properly. 

**Problem**: When users performed a search using the `q` parameter (as sent by the `api_keys_list` frontend component), the search filter was being silently ignored, resulting in all API keys being returned regardless of the search query.

**Fix**: The `GetAPIKeys` method in the API key service now properly configures the global search to filter against the `name` column using a `GlobalSearchConfig`. This ensures that when a user searches in the API keys list, it correctly filters results by key name.

**Testing**: Added a new test (`TestAPIKeyService_GetAPIKeys_GlobalSearch`) that verifies the `q` filter correctly matches only API keys whose names contain the search term, confirming the regression is fixed.
<!-- kody-pr-summary:end -->